### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 
 [workspace]
 

--- a/despatma-lib/CHANGELOG.md
+++ b/despatma-lib/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/chesedo/despatma/compare/despatma-lib-v0.1.1...despatma-lib-v0.2.0) - 2024-08-14
+
+### Other
+- update Cargo.toml dependencies
+
 ## [0.1.1](https://github.com/chesedo/despatma/compare/despatma-lib-v0.1.0...despatma-lib-v0.1.1) - 2024-08-09
 
 ### Other

--- a/despatma/CHANGELOG.md
+++ b/despatma/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/chesedo/despatma/compare/despatma-v0.1.1...despatma-v0.2.0) - 2024-08-14
+
+### Added
+- dependency_container ([#9](https://github.com/chesedo/despatma/pull/9))
+
+### Other
+- [**breaking**] change `Visitable` to use static dispatch instead ([#8](https://github.com/chesedo/despatma/pull/8))
+- update all docs to compile successfully ([#6](https://github.com/chesedo/despatma/pull/6))
+
 ## [0.1.1](https://github.com/chesedo/despatma/compare/despatma-v0.1.0...despatma-v0.1.1) - 2024-08-09
 
 ### Other

--- a/despatma/Cargo.toml
+++ b/despatma/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["macro", "design", "patterns"]
 proc-macro = true
 
 [dependencies]
-despatma-lib = { path = "../despatma-lib", version = "0.1.1" }
+despatma-lib = { path = "../despatma-lib", version = "0.2.0" }
 indexmap = "2.3.0"
 proc-macro-error = "1.0.4"
 


### PR DESCRIPTION
## 🤖 New release
* `despatma`: 0.1.1 -> 0.2.0
* `despatma-lib`: 0.1.1 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `despatma`
<blockquote>

## [0.2.0](https://github.com/chesedo/despatma/compare/despatma-v0.1.1...despatma-v0.2.0) - 2024-08-14

### Added
- dependency_container ([#9](https://github.com/chesedo/despatma/pull/9))

### Other
- [**breaking**] change `Visitable` to use static dispatch instead ([#8](https://github.com/chesedo/despatma/pull/8))
- update all docs to compile successfully ([#6](https://github.com/chesedo/despatma/pull/6))
</blockquote>

## `despatma-lib`
<blockquote>

## [0.2.0](https://github.com/chesedo/despatma/compare/despatma-lib-v0.1.1...despatma-lib-v0.2.0) - 2024-08-14

### Other
- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).