### PR TITLE
feat: dependency_container

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [github]: https://img.shields.io/badge/github-8da0cb?style=for-the-badge&labelColor=555555&logo=github
 [crates-io]: https://img.shields.io/badge/crates.io-fc8d62?style=for-the-badge&labelColor=555555&logo=rust
 [docs-rs]: https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logoColor=white&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K
-[workflow]: https://img.shields.io/github/workflow/status/chesedo/despatma/Rust?color=green&label=&labelColor=555555&logo=github%20actions&logoColor=white&style=for-the-badge
+[workflow]: https://img.shields.io/github/actions/workflow/status/chesedo/despatma/rust.yml?color=green&label=&labelColor=555555&logo=github%20actions&logoColor=white&style=for-the-badge
 
 Despatma is a collection of `des`ign `pat`tern `ma`cros (`despatma`) born from a [Honours project](https://github.com/chesedo/cos-700/blob/master/Report%20-%20Final.pdf).
 It aims to provide the most common implementations for design patterns at run-time.
@@ -14,6 +14,7 @@ The end goal is to be as [Loki](http://loki-lib.sourceforge.net/) is for C++ and
 The following patterns are currently implemented:
 - [abstract_factory] - with the help of [interpolate_traits] macro
 - [visitor]
+- [dependency_container]
 
 Next up for investigation is:
 - [ ] Decorator
@@ -26,3 +27,4 @@ Next up for investigation is:
 [abstract_factory]: https://docs.rs/despatma/latest/despatma/attr.abstract_factory.html
 [interpolate_traits]: https://docs.rs/despatma/latest/despatma/attr.interpolate_traits.html
 [visitor]: https://docs.rs/despatma/latest/despatma/macro.visitor.html
+[dependency_container]: https://docs.rs/despatma/latest/despatma/macro.dependency_container.html

--- a/despatma/Cargo.toml
+++ b/despatma/Cargo.toml
@@ -33,3 +33,4 @@ pretty_assertions = { workspace = true }
 syn = { workspace = true, features = ["extra-traits"] }
 trybuild = "1.0"
 tokio = { version = "1.39.2", features = ["macros", "rt-multi-thread", "time"] }
+auto_impl = "1.2.0"

--- a/despatma/Cargo.toml
+++ b/despatma/Cargo.toml
@@ -15,9 +15,12 @@ proc-macro = true
 
 [dependencies]
 despatma-lib = { path = "../despatma-lib", version = "0.1.1" }
+indexmap = "2.3.0"
+proc-macro-error = "1.0.4"
 
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
+strsim = "0.11.1"
 syn = { workspace = true, features = ["full"] }
 tokenstream2-tmpl = { workspace = true }
 

--- a/despatma/Cargo.toml
+++ b/despatma/Cargo.toml
@@ -32,3 +32,4 @@ macrotest = "1.0"
 pretty_assertions = { workspace = true }
 syn = { workspace = true, features = ["extra-traits"] }
 trybuild = "1.0"
+tokio = { version = "1.39.2", features = ["macros", "rt-multi-thread", "time"] }

--- a/despatma/README.md
+++ b/despatma/README.md
@@ -1,0 +1,13 @@
+Despatma is a collection of `des`ign `pat`tern `ma`cros (`despatma`).
+It aims to provide the most common implementations for design patterns at run-time.
+
+This project is still a **work in progress**.
+The end goal is to be as [Loki](http://loki-lib.sourceforge.net/) is for C++ and more if possible.
+The following patterns are currently implemented:
+- [abstract_factory] - with the help of [interpolate_traits] macro
+- [visitor]
+- [dependency_container]
+
+[abstract_factory]: https://docs.rs/despatma/latest/despatma/attr.abstract_factory.html
+[visitor]: https://docs.rs/despatma/latest/despatma/macro.visitor.html
+[dependency_container]: https://docs.rs/despatma/latest/despatma/macro.dependency_container.html

--- a/despatma/src/dependency_container.rs
+++ b/despatma/src/dependency_container.rs
@@ -1,0 +1,264 @@
+use indexmap::IndexMap;
+use proc_macro2::TokenStream;
+use proc_macro_error::emit_error;
+use quote::{quote, ToTokens};
+use strsim::levenshtein;
+use syn::{Block, Ident, ImplItem, ItemImpl, Signature, Type};
+
+#[cfg_attr(test, derive(Eq, PartialEq, Debug))]
+pub struct Container {
+    self_ty: Type,
+    dependencies: IndexMap<Ident, Dependency>,
+}
+
+#[cfg_attr(test, derive(Eq, PartialEq, Debug))]
+struct Dependency {
+    sig: Signature,
+    block: Block,
+    dependencies: Vec<ChildDependency>,
+}
+
+#[cfg_attr(test, derive(Eq, PartialEq, Debug))]
+struct ChildDependency {
+    ident: Ident,
+    is_ref: bool,
+}
+
+impl Container {
+    pub fn from_item_impl(item_impl: ItemImpl) -> Self {
+        let dependencies = item_impl
+            .items
+            .into_iter()
+            .filter_map(|item| match item {
+                ImplItem::Fn(item_fn) => {
+                    let dependencies = item_fn
+                        .sig
+                        .inputs
+                        .iter()
+                        .filter_map(|input| match input {
+                            syn::FnArg::Receiver(_) => None,
+                            syn::FnArg::Typed(pat_type) => {
+                                let ident = match pat_type.pat.as_ref() {
+                                    syn::Pat::Ident(pat_ident) => pat_ident.ident.clone(),
+                                    _ => todo!(),
+                                };
+                                Some(ChildDependency {
+                                    ident,
+                                    is_ref: matches!(pat_type.ty.as_ref(), Type::Reference(_)),
+                                })
+                            }
+                        })
+                        .collect();
+
+                    Some((
+                        item_fn.sig.ident.clone(),
+                        Dependency {
+                            sig: item_fn.sig,
+                            block: item_fn.block,
+                            dependencies,
+                        },
+                    ))
+                }
+                _ => todo!(),
+            })
+            .collect();
+
+        Self {
+            self_ty: item_impl.self_ty.as_ref().clone(),
+            dependencies,
+        }
+    }
+
+    pub fn validate(&self) {
+        validate_dependencies(&self.dependencies);
+    }
+}
+
+fn validate_dependencies(dependencies: &IndexMap<Ident, Dependency>) {
+    // Check if all dependencies are present
+    for dep in dependencies.values() {
+        for child_dep in &dep.dependencies {
+            if !dependencies.contains_key(&child_dep.ident) {
+                if let Some(best_match) =
+                    get_best_dependency_match(dependencies, &child_dep.ident.to_string())
+                {
+                    emit_error!(child_dep.ident, "The '{}' dependency has not been registered", child_dep.ident; hint = best_match.span() => format!("Did you mean `{}`?", best_match));
+                } else {
+                    emit_error!(
+                        child_dep.ident,
+                        "Dependency not found. Did you forget to add it?";
+                        hint = "Try adding it with `fn {}(&self) ...`", child_dep.ident
+                    );
+                }
+            }
+        }
+    }
+}
+
+const MISSPELLING_THRESHOLD: usize = 3;
+
+fn get_best_dependency_match<'a>(
+    dependencies: &'a IndexMap<Ident, Dependency>,
+    needle: &str,
+) -> Option<&'a Ident> {
+    dependencies
+        .keys()
+        .map(|d| (d, levenshtein(&needle.to_string(), &d.to_string())))
+        .filter(|(_, distance)| *distance <= MISSPELLING_THRESHOLD)
+        .min_by_key(|(_, distance)| *distance)
+        .map(|(d, _)| d)
+}
+
+impl ToTokens for Container {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self {
+            self_ty,
+            dependencies,
+        } = self;
+
+        let dependencies = dependencies.values().map(|dep| {
+            let Dependency {  sig, block, dependencies } = dep;
+            let Signature {
+                constness,
+                asyncness,
+                unsafety,
+                abi,
+                fn_token,
+                ident,
+                generics,
+                paren_token: _,
+                inputs,
+                variadic,
+                output,
+            } = sig;
+
+            let create_ident = Ident::new(&format!("create_{}", ident), ident.span());
+            let (create_dependencies, dependency_params): (Vec<_>, Vec<_>) = dependencies.iter().map(|dep| {
+                let ChildDependency { ident, is_ref } = dep;
+
+                let param = if *is_ref {
+                    quote! { &#ident }
+                } else {
+                    quote! { #ident }
+                };
+
+                (quote! {
+                    let #ident = self.#ident();
+                }, param)
+            }).unzip();
+
+
+            quote! {
+                #constness #asyncness #unsafety #abi #fn_token #create_ident #generics (#inputs, #variadic) #output #block
+
+                pub #constness #asyncness #unsafety #abi #fn_token #ident #generics(&self) #output {
+                    #(#create_dependencies)*
+
+                    self.#create_ident(#(#dependency_params),*)
+                }
+            }
+        });
+
+        tokens.extend(quote! {
+            struct #self_ty;
+
+            impl #self_ty {
+                fn new() -> Self {
+                    Self
+                }
+
+                #(#dependencies)*
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod inputs {
+        use syn::parse_quote;
+
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn simple() {
+            let container = Container::from_item_impl(parse_quote!(
+                impl DependencyContainer {
+                    fn config(&self) -> Config {
+                        Config
+                    }
+                }
+            ));
+            let expected = Container {
+                self_ty: parse_quote!(DependencyContainer),
+                dependencies: IndexMap::from_iter(vec![(
+                    parse_quote!(config),
+                    Dependency {
+                        sig: parse_quote!(fn config(&self) -> Config),
+                        block: parse_quote!({ Config }),
+                        dependencies: vec![],
+                    },
+                )]),
+            };
+
+            assert_eq!(container, expected);
+        }
+
+        #[test]
+        fn with_dependency() {
+            let container = Container::from_item_impl(parse_quote!(
+                impl Dependencies {
+                    fn service(&self, config: Config) -> Service {
+                        Service
+                    }
+                }
+            ));
+            let expected = Container {
+                self_ty: parse_quote!(Dependencies),
+                dependencies: IndexMap::from_iter(vec![(
+                    parse_quote!(service),
+                    Dependency {
+                        sig: parse_quote!(fn service(&self, config: Config) -> Service),
+                        block: parse_quote!({ Service }),
+                        dependencies: vec![ChildDependency {
+                            ident: parse_quote!(config),
+                            is_ref: false,
+                        }],
+                    },
+                )]),
+            };
+
+            assert_eq!(container, expected);
+        }
+
+        #[test]
+        fn with_ref_dependency() {
+            let container = Container::from_item_impl(parse_quote!(
+                impl Dependencies {
+                    fn service(&self, config: &Config) -> Service {
+                        Service
+                    }
+                }
+            ));
+            let expected = Container {
+                self_ty: parse_quote!(Dependencies),
+                dependencies: IndexMap::from_iter(vec![(
+                    parse_quote!(service),
+                    Dependency {
+                        sig: parse_quote!(fn service(&self, config: &Config) -> Service),
+                        block: parse_quote!({ Service }),
+                        dependencies: vec![ChildDependency {
+                            ident: parse_quote!(config),
+                            is_ref: true,
+                        }],
+                    },
+                )]),
+            };
+
+            assert_eq!(container, expected);
+        }
+    }
+}

--- a/despatma/src/dependency_container/mod.rs
+++ b/despatma/src/dependency_container/mod.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{Block, Ident, ImplItem, ItemImpl, Signature, Token, Type};
 
-use self::visitor::{AsyncVisitor, ImplTraitButRegisteredConcrete, Visit, VisitMut, WiringVisitor};
+use self::visitor::{CheckWiring, FixAsyncTree, ImplTraitButRegisteredConcrete, Visit, VisitMut};
 
 mod visitor;
 
@@ -185,7 +185,7 @@ impl Container {
     }
 
     pub fn validate(&self) {
-        let mut wiring_visitor = WiringVisitor::new(self.dependencies.keys().cloned().collect());
+        let mut wiring_visitor = CheckWiring::new(self.dependencies.keys().cloned().collect());
 
         wiring_visitor.visit_container(self);
         wiring_visitor.emit_errors();
@@ -197,7 +197,7 @@ impl Container {
     }
 
     pub fn update(&mut self) {
-        let mut async_visitor = AsyncVisitor::new(self.dependencies.clone());
+        let mut async_visitor = FixAsyncTree::new(self.dependencies.clone());
         async_visitor.visit_container_mut(self);
     }
 }

--- a/despatma/src/dependency_container/mod.rs
+++ b/despatma/src/dependency_container/mod.rs
@@ -166,8 +166,8 @@ impl Dependency {
             attrs,
             sig,
             block: _,
-            dependencies,
             is_async,
+            dependencies,
         } = self;
         let Signature {
             constness,

--- a/despatma/src/dependency_container/mod.rs
+++ b/despatma/src/dependency_container/mod.rs
@@ -4,7 +4,9 @@ use indexmap::IndexMap;
 use proc_macro2::TokenStream;
 use proc_macro_error::emit_error;
 use quote::{quote, ToTokens};
-use syn::{Attribute, Block, Ident, ImplItem, ItemImpl, Signature, Token, Type};
+use syn::{
+    Attribute, Block, FnArg, Ident, ImplItem, ImplItemFn, ItemImpl, Pat, Signature, Token, Type,
+};
 
 use self::visitor::{CheckWiring, FixAsyncTree, ImplTraitButRegisteredConcrete, Visit, VisitMut};
 
@@ -17,6 +19,91 @@ pub struct Container {
     dependencies: IndexMap<Ident, Rc<RefCell<Dependency>>>,
 }
 
+impl Container {
+    pub fn from_item_impl(item_impl: ItemImpl) -> Self {
+        let dependencies = item_impl
+            .items
+            .into_iter()
+            .filter_map(|impl_item| match impl_item {
+                ImplItem::Fn(impl_item_fn) => Some((
+                    impl_item_fn.sig.ident.clone(),
+                    Rc::new(RefCell::new(Dependency::from_impl_item_fn(impl_item_fn))),
+                )),
+                impl_item => {
+                    emit_error!(impl_item, "This impl item is not supported");
+                    None
+                }
+            })
+            .collect();
+
+        Self {
+            attrs: item_impl.attrs,
+            self_ty: item_impl.self_ty.as_ref().clone(),
+            dependencies,
+        }
+    }
+
+    /// Validate the supplied input is correct
+    pub fn validate(&self) {
+        self.validate_wiring();
+        self.validate_rpit_requesting_concrete();
+    }
+
+    fn validate_wiring(&self) {
+        let mut wiring_visitor = CheckWiring::new(self.dependencies.keys().cloned().collect());
+
+        wiring_visitor.visit_container(self);
+        wiring_visitor.emit_errors();
+    }
+
+    fn validate_rpit_requesting_concrete(&self) {
+        let mut rpit_requesting_concrete =
+            ImplTraitButRegisteredConcrete::new(self.dependencies.clone());
+        rpit_requesting_concrete.visit_container(self);
+        rpit_requesting_concrete.emit_errors();
+    }
+
+    /// Update the container to fix any issues
+    pub fn update(&mut self) {
+        let mut async_visitor = FixAsyncTree::new(self.dependencies.clone());
+        async_visitor.visit_container_mut(self);
+    }
+}
+
+impl ToTokens for Container {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let self_attrs = &self.attrs;
+        let self_ty = &self.self_ty;
+        let self_dependencies = &self.dependencies;
+
+        let dependencies = self_dependencies.values().map(|dep| {
+            let dep_ref = dep.borrow();
+
+            let (create_ident, create_dependency_fn) = dep_ref.create_dependency_fn();
+            let dependency_fn = dep_ref.dependency_fn(create_ident, self_dependencies);
+
+            quote! {
+                #create_dependency_fn
+
+                #dependency_fn
+            }
+        });
+
+        tokens.extend(quote! {
+            #(#self_attrs)*
+            struct #self_ty;
+
+            impl #self_ty {
+                fn new() -> Self {
+                    Self
+                }
+
+                #(#dependencies)*
+            }
+        });
+    }
+}
+
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 struct Dependency {
     attrs: Vec<Attribute>,
@@ -27,6 +114,18 @@ struct Dependency {
 }
 
 impl Dependency {
+    fn from_impl_item_fn(impl_item_fn: ImplItemFn) -> Self {
+        let dependencies = ChildDependency::from_impl_item_fn(&impl_item_fn);
+
+        Self {
+            attrs: impl_item_fn.attrs,
+            is_async: impl_item_fn.sig.asyncness.is_some(),
+            sig: impl_item_fn.sig,
+            block: impl_item_fn.block,
+            dependencies,
+        }
+    }
+
     fn create_dependency_fn(&self) -> (Ident, TokenStream) {
         let Self {
             attrs: _,
@@ -86,10 +185,11 @@ impl Dependency {
 
         let (create_dependencies, dependency_params): (Vec<_>, Vec<_>) = dependencies
             .iter()
-            .map(|dep| {
-                let ChildDependency { ident, is_ref } = dep;
+            .map(|child_dependency| {
+                let ChildDependency { ident, is_ref } = child_dependency;
 
-                // The dependency might not exist if it was mispelt since we still try our best to generate the code
+                // The dependency might not exist if it was mispelt since we still try our best to generate the code.
+                // So defaulting to false
                 let is_async = container_dependencies
                     .get(ident)
                     .map(|d| d.borrow().is_async)
@@ -101,27 +201,26 @@ impl Dependency {
                     quote! { #ident }
                 };
 
-                let awai = if is_async {
+                let await_key = if is_async {
                     Some(quote! { .await })
                 } else {
                     None
                 };
 
-                (
-                    quote! {
-                        let #ident = self.#ident()#awai;
-                    },
-                    param,
-                )
+                let create_stmt = quote! {
+                    let #ident = self.#ident()#await_key;
+                };
+
+                (create_stmt, param)
             })
             .unzip();
 
-        let pub_asyncness = if *is_async {
+        let async_key = if *is_async {
             Some(<Token![async]>::default())
         } else {
             None
         };
-        let pub_await = if asyncness.is_some() {
+        let await_key = if asyncness.is_some() {
             Some(quote! { .await })
         } else {
             None
@@ -129,10 +228,10 @@ impl Dependency {
 
         quote! {
             #(#attrs)*
-            pub #constness #pub_asyncness #unsafety #abi #fn_token #ident #generics(&self) #output {
+            pub #constness #async_key #unsafety #abi #fn_token #ident #generics(&self) #output {
                 #(#create_dependencies)*
 
-                self.#create_ident(#(#dependency_params),*)#pub_await
+                self.#create_ident(#(#dependency_params),*)#await_key
             }
         }
     }
@@ -144,109 +243,29 @@ struct ChildDependency {
     is_ref: bool,
 }
 
-impl Container {
-    pub fn from_item_impl(item_impl: ItemImpl) -> Self {
-        let dependencies = item_impl
-            .items
-            .into_iter()
-            .filter_map(|item| match item {
-                ImplItem::Fn(item_fn) => {
-                    let dependencies = item_fn
-                        .sig
-                        .inputs
-                        .iter()
-                        .filter_map(|input| match input {
-                            syn::FnArg::Receiver(_) => None,
-                            syn::FnArg::Typed(pat_type) => {
-                                let ident = match pat_type.pat.as_ref() {
-                                    syn::Pat::Ident(pat_ident) => pat_ident.ident.clone(),
-                                    pat => {
-                                        emit_error!(pat, "This argument type is not supported");
-                                        return None;
-                                    }
-                                };
-                                Some(ChildDependency {
-                                    ident,
-                                    is_ref: matches!(pat_type.ty.as_ref(), Type::Reference(_)),
-                                })
-                            }
-                        })
-                        .collect();
-
-                    Some((
-                        item_fn.sig.ident.clone(),
-                        Rc::new(RefCell::new(Dependency {
-                            attrs: item_fn.attrs,
-                            is_async: item_fn.sig.asyncness.is_some(),
-                            sig: item_fn.sig,
-                            block: item_fn.block,
-                            dependencies,
-                        })),
-                    ))
-                }
-                impl_item => {
-                    emit_error!(impl_item, "This impl item is not supported");
-                    None
+impl ChildDependency {
+    fn from_impl_item_fn(impl_item_fn: &ImplItemFn) -> Vec<Self> {
+        impl_item_fn
+            .sig
+            .inputs
+            .iter()
+            .filter_map(|fn_arg| match fn_arg {
+                FnArg::Receiver(_) => None,
+                FnArg::Typed(pat_type) => {
+                    let ident = match pat_type.pat.as_ref() {
+                        Pat::Ident(pat_ident) => pat_ident.ident.clone(),
+                        pat => {
+                            emit_error!(pat, "This argument type is not supported");
+                            return None;
+                        }
+                    };
+                    Some(Self {
+                        ident,
+                        is_ref: matches!(pat_type.ty.as_ref(), Type::Reference(_)),
+                    })
                 }
             })
-            .collect();
-
-        Self {
-            attrs: item_impl.attrs,
-            self_ty: item_impl.self_ty.as_ref().clone(),
-            dependencies,
-        }
-    }
-
-    pub fn validate(&self) {
-        let mut wiring_visitor = CheckWiring::new(self.dependencies.keys().cloned().collect());
-
-        wiring_visitor.visit_container(self);
-        wiring_visitor.emit_errors();
-
-        let mut rpit_requesting_concrete =
-            ImplTraitButRegisteredConcrete::new(self.dependencies.clone());
-        rpit_requesting_concrete.visit_container(self);
-        rpit_requesting_concrete.emit_errors();
-    }
-
-    pub fn update(&mut self) {
-        let mut async_visitor = FixAsyncTree::new(self.dependencies.clone());
-        async_visitor.visit_container_mut(self);
-    }
-}
-
-impl ToTokens for Container {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let self_attrs = &self.attrs;
-        let self_ty = &self.self_ty;
-        let self_dependencies = &self.dependencies;
-
-        let dependencies = self_dependencies.values().map(|dep| {
-            let dep_ref = dep.borrow();
-
-            let (create_ident, create_dependency_fn) = dep_ref.create_dependency_fn();
-            let dependency_fn = dep_ref.dependency_fn(create_ident, self_dependencies);
-
-            quote! {
-                #create_dependency_fn
-
-                #dependency_fn
-            }
-        });
-
-        tokens.extend(quote! {
-            #(#self_attrs)*
-            struct #self_ty;
-
-            impl #self_ty {
-                fn new() -> Self {
-                    Self
-                }
-
-                #(#dependencies)*
-            }
-        });
+            .collect()
     }
 }
 

--- a/despatma/src/dependency_container/mod.rs
+++ b/despatma/src/dependency_container/mod.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{Block, Ident, ImplItem, ItemImpl, Signature, Token, Type};
 
-use self::visitor::{AsyncVisitor, Visit, VisitMut, WiringVisitor};
+use self::visitor::{AsyncVisitor, ImplTraitButRegisteredConcrete, Visit, VisitMut, WiringVisitor};
 
 mod visitor;
 
@@ -80,6 +80,11 @@ impl Container {
 
         wiring_visitor.visit_container(self);
         wiring_visitor.emit_errors();
+
+        let mut rpit_requesting_concrete =
+            ImplTraitButRegisteredConcrete::new(self.dependencies.clone());
+        rpit_requesting_concrete.visit_container(self);
+        rpit_requesting_concrete.emit_errors();
     }
 
     pub fn update(&mut self) {

--- a/despatma/src/dependency_container/mod.rs
+++ b/despatma/src/dependency_container/mod.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use indexmap::IndexMap;
 use proc_macro2::TokenStream;
+use proc_macro_error::emit_error;
 use quote::{quote, ToTokens};
 use syn::{Block, Ident, ImplItem, ItemImpl, Signature, Token, Type};
 
@@ -154,7 +155,10 @@ impl Container {
                             syn::FnArg::Typed(pat_type) => {
                                 let ident = match pat_type.pat.as_ref() {
                                     syn::Pat::Ident(pat_ident) => pat_ident.ident.clone(),
-                                    _ => todo!(),
+                                    pat => {
+                                        emit_error!(pat, "This argument type is not supported");
+                                        return None;
+                                    }
                                 };
                                 Some(ChildDependency {
                                     ident,
@@ -174,7 +178,10 @@ impl Container {
                         })),
                     ))
                 }
-                _ => todo!(),
+                impl_item => {
+                    emit_error!(impl_item, "This impl item is not supported");
+                    None
+                }
             })
             .collect();
 

--- a/despatma/src/dependency_container/mod.rs
+++ b/despatma/src/dependency_container/mod.rs
@@ -1,22 +1,25 @@
+use std::{cell::RefCell, rc::Rc};
+
 use indexmap::IndexMap;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{Block, Ident, ImplItem, ItemImpl, Signature, Type};
+use syn::{Block, Ident, ImplItem, ItemImpl, Signature, Token, Type};
 
-use self::visitor::{MutVisitor, WiringVisitor};
+use self::visitor::{AsyncVisitor, Visit, VisitMut, WiringVisitor};
 
 mod visitor;
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct Container {
     self_ty: Type,
-    dependencies: IndexMap<Ident, Dependency>,
+    dependencies: IndexMap<Ident, Rc<RefCell<Dependency>>>,
 }
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 struct Dependency {
     sig: Signature,
     block: Block,
+    is_async: bool,
     dependencies: Vec<ChildDependency>,
 }
 
@@ -54,11 +57,12 @@ impl Container {
 
                     Some((
                         item_fn.sig.ident.clone(),
-                        Dependency {
+                        Rc::new(RefCell::new(Dependency {
+                            is_async: item_fn.sig.asyncness.is_some(),
                             sig: item_fn.sig,
                             block: item_fn.block,
                             dependencies,
-                        },
+                        })),
                     ))
                 }
                 _ => todo!(),
@@ -75,18 +79,24 @@ impl Container {
         let mut wiring_visitor = WiringVisitor::new(self.dependencies.keys().cloned().collect());
 
         wiring_visitor.visit_container(&self);
+        wiring_visitor.emit_errors();
+    }
+
+    pub fn update(&mut self) {
+        let mut async_visitor = AsyncVisitor::new(self.dependencies.clone());
+
+        async_visitor.visit_container_mut(self);
     }
 }
 
 impl ToTokens for Container {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let Self {
-            self_ty,
-            dependencies,
-        } = self;
+        let self_ty = &self.self_ty;
+        let self_dependencies = &self.dependencies;
 
-        let dependencies = dependencies.values().map(|dep| {
-            let Dependency {  sig, block, dependencies } = dep;
+        let dependencies = self_dependencies.values().map(|dep| {
+            let dep_ref = dep.borrow();
+            let Dependency {  sig, block, dependencies, is_async } = &*dep_ref;
             let Signature {
                 constness,
                 asyncness,
@@ -105,25 +115,45 @@ impl ToTokens for Container {
             let (create_dependencies, dependency_params): (Vec<_>, Vec<_>) = dependencies.iter().map(|dep| {
                 let ChildDependency { ident, is_ref } = dep;
 
+                // The dependency might not exist if it was mispelt since we still try our best to generate the code
+                let is_async = self_dependencies.get(ident).map(|d| d.borrow().is_async).unwrap_or_default();
+
                 let param = if *is_ref {
                     quote! { &#ident }
                 } else {
                     quote! { #ident }
                 };
 
+                let awai = if is_async {
+                    Some(quote! { .await })
+                } else {
+                    None
+                };
+
                 (quote! {
-                    let #ident = self.#ident();
+                    let #ident = self.#ident()#awai;
                 }, param)
             }).unzip();
+
+            let pub_asyncness = if *is_async {
+                Some(<Token![async]>::default())
+            } else {
+                None
+            };
+            let pub_await = if asyncness.is_some() {
+                Some(quote! { .await })
+            } else {
+                None
+            };
 
 
             quote! {
                 #constness #asyncness #unsafety #abi #fn_token #create_ident #generics (#inputs, #variadic) #output #block
 
-                pub #constness #asyncness #unsafety #abi #fn_token #ident #generics(&self) #output {
+                pub #constness #pub_asyncness #unsafety #abi #fn_token #ident #generics(&self) #output {
                     #(#create_dependencies)*
 
-                    self.#create_ident(#(#dependency_params),*)
+                    self.#create_ident(#(#dependency_params),*)#pub_await
                 }
             }
         });
@@ -165,11 +195,12 @@ mod tests {
                 self_ty: parse_quote!(DependencyContainer),
                 dependencies: IndexMap::from_iter(vec![(
                     parse_quote!(config),
-                    Dependency {
+                    Rc::new(RefCell::new(Dependency {
                         sig: parse_quote!(fn config(&self) -> Config),
                         block: parse_quote!({ Config }),
+                        is_async: false,
                         dependencies: vec![],
-                    },
+                    })),
                 )]),
             };
 
@@ -189,14 +220,15 @@ mod tests {
                 self_ty: parse_quote!(Dependencies),
                 dependencies: IndexMap::from_iter(vec![(
                     parse_quote!(service),
-                    Dependency {
+                    Rc::new(RefCell::new(Dependency {
                         sig: parse_quote!(fn service(&self, config: Config) -> Service),
                         block: parse_quote!({ Service }),
+                        is_async: false,
                         dependencies: vec![ChildDependency {
                             ident: parse_quote!(config),
                             is_ref: false,
                         }],
-                    },
+                    })),
                 )]),
             };
 
@@ -216,15 +248,58 @@ mod tests {
                 self_ty: parse_quote!(Dependencies),
                 dependencies: IndexMap::from_iter(vec![(
                     parse_quote!(service),
-                    Dependency {
+                    Rc::new(RefCell::new(Dependency {
                         sig: parse_quote!(fn service(&self, config: &Config) -> Service),
                         block: parse_quote!({ Service }),
+                        is_async: false,
                         dependencies: vec![ChildDependency {
                             ident: parse_quote!(config),
                             is_ref: true,
                         }],
-                    },
+                    })),
                 )]),
+            };
+
+            assert_eq!(container, expected);
+        }
+
+        #[test]
+        fn with_async_dependency() {
+            let container = Container::from_item_impl(parse_quote!(
+                impl Dependencies {
+                    fn service(&self, config: Config) -> Service {
+                        Service
+                    }
+                    async fn config(&self) -> Config {
+                        Config
+                    }
+                }
+            ));
+            let expected = Container {
+                self_ty: parse_quote!(Dependencies),
+                dependencies: IndexMap::from_iter(vec![
+                    (
+                        parse_quote!(service),
+                        Rc::new(RefCell::new(Dependency {
+                            sig: parse_quote!(fn service(&self, config: Config) -> Service),
+                            block: parse_quote!({ Service }),
+                            is_async: false,
+                            dependencies: vec![ChildDependency {
+                                ident: parse_quote!(config),
+                                is_ref: false,
+                            }],
+                        })),
+                    ),
+                    (
+                        parse_quote!(config),
+                        Rc::new(RefCell::new(Dependency {
+                            sig: parse_quote!(async fn config(&self) -> Config),
+                            block: parse_quote!({ Config }),
+                            is_async: true,
+                            dependencies: vec![],
+                        })),
+                    ),
+                ]),
             };
 
             assert_eq!(container, expected);

--- a/despatma/src/dependency_container/mod.rs
+++ b/despatma/src/dependency_container/mod.rs
@@ -78,7 +78,7 @@ impl Container {
     pub fn validate(&self) {
         let mut wiring_visitor = WiringVisitor::new(self.dependencies.keys().cloned().collect());
 
-        wiring_visitor.visit_container(&self);
+        wiring_visitor.visit_container(self);
         wiring_visitor.emit_errors();
     }
 

--- a/despatma/src/dependency_container/visitor/async_visitor.rs
+++ b/despatma/src/dependency_container/visitor/async_visitor.rs
@@ -88,41 +88,37 @@ mod tests {
         let mut async_visitor = AsyncVisitor::new(container.dependencies.clone());
         async_visitor.visit_container_mut(&mut container);
 
-        assert_eq!(
-            container
+        assert!(
+            !container
                 .dependencies
                 .get::<Ident>(&parse_quote!(config))
                 .unwrap()
                 .borrow()
-                .is_async,
-            false
+                .is_async
         );
-        assert_eq!(
+        assert!(
             container
                 .dependencies
                 .get::<Ident>(&parse_quote!(logger))
                 .unwrap()
                 .borrow()
-                .is_async,
-            true
+                .is_async
         );
-        assert_eq!(
+        assert!(
             container
                 .dependencies
                 .get::<Ident>(&parse_quote!(db))
                 .unwrap()
                 .borrow()
-                .is_async,
-            true
+                .is_async
         );
-        assert_eq!(
+        assert!(
             container
                 .dependencies
                 .get::<Ident>(&parse_quote!(service))
                 .unwrap()
                 .borrow()
-                .is_async,
-            true
+                .is_async
         );
     }
 }

--- a/despatma/src/dependency_container/visitor/async_visitor.rs
+++ b/despatma/src/dependency_container/visitor/async_visitor.rs
@@ -35,7 +35,7 @@ impl VisitMut for AsyncVisitor {
             .dependencies
             .iter()
             .filter_map(|d| self.dependencies.get(&d.ident))
-            .map(|d| d.clone())
+            .cloned()
             .collect();
 
         let has_sync_child = dependencies.iter().any(|d| {

--- a/despatma/src/dependency_container/visitor/async_visitor.rs
+++ b/despatma/src/dependency_container/visitor/async_visitor.rs
@@ -1,0 +1,128 @@
+use std::{cell::RefCell, collections::HashSet, rc::Rc};
+
+use indexmap::IndexMap;
+use syn::Ident;
+
+use crate::dependency_container::Dependency;
+
+use super::VisitMut;
+
+/// Visitor used to determine if any child dependencies in the calltree is async. Because if any
+/// child dependencies are async, then the parent dependency must also be async. Which this
+/// visitor updates correcly.
+pub struct AsyncVisitor {
+    dependencies: IndexMap<Ident, Rc<RefCell<Dependency>>>,
+    visited_dependencies: HashSet<Ident>,
+}
+
+impl AsyncVisitor {
+    pub fn new(dependencies: IndexMap<Ident, Rc<RefCell<Dependency>>>) -> Self {
+        Self {
+            dependencies,
+            visited_dependencies: HashSet::new(),
+        }
+    }
+}
+
+impl VisitMut for AsyncVisitor {
+    fn visit_dependency_mut(&mut self, dependency: &mut Dependency) {
+        // We want to be efficient and not visit the same dependency multiple times
+        if self.visited_dependencies.contains(&dependency.sig.ident) {
+            return;
+        }
+
+        let dependencies: Vec<_> = dependency
+            .dependencies
+            .iter()
+            .filter_map(|d| self.dependencies.get(&d.ident))
+            .map(|d| d.clone())
+            .collect();
+
+        let has_sync_child = dependencies.iter().any(|d| {
+            let mut d = d.borrow_mut();
+
+            // Make sure we update any child dependencies first as they might be in an async calltree.
+            // Basically the idea is to visit the calltree in a depth-first manner.
+            self.visit_dependency_mut(&mut d);
+
+            d.is_async
+        });
+
+        dependency.is_async |= has_sync_child;
+
+        self.visited_dependencies
+            .insert(dependency.sig.ident.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_quote;
+
+    use crate::dependency_container::Container;
+
+    use super::*;
+
+    #[test]
+    fn make_async() {
+        let mut container = Container::from_item_impl(parse_quote!(
+            impl Dependencies {
+                fn config(&self) -> Config {
+                    Config
+                }
+
+                fn service(&self, config: Config, db: Db) -> Service {
+                    Service(config, db)
+                }
+
+                async fn logger(&self) -> Logger {
+                    Logger
+                }
+
+                fn db(&self, logger: Logger) -> Db {
+                    Db
+                }
+            }
+        ));
+
+        let mut async_visitor = AsyncVisitor::new(container.dependencies.clone());
+        async_visitor.visit_container_mut(&mut container);
+
+        assert_eq!(
+            container
+                .dependencies
+                .get::<Ident>(&parse_quote!(config))
+                .unwrap()
+                .borrow()
+                .is_async,
+            false
+        );
+        assert_eq!(
+            container
+                .dependencies
+                .get::<Ident>(&parse_quote!(logger))
+                .unwrap()
+                .borrow()
+                .is_async,
+            true
+        );
+        assert_eq!(
+            container
+                .dependencies
+                .get::<Ident>(&parse_quote!(db))
+                .unwrap()
+                .borrow()
+                .is_async,
+            true
+        );
+        assert_eq!(
+            container
+                .dependencies
+                .get::<Ident>(&parse_quote!(service))
+                .unwrap()
+                .borrow()
+                .is_async,
+            true
+        );
+    }
+}

--- a/despatma/src/dependency_container/visitor/check_wiring.rs
+++ b/despatma/src/dependency_container/visitor/check_wiring.rs
@@ -9,7 +9,7 @@ use super::{visit_child_dependency, Visit};
 /// This visitor is responsible for checking if all dependencies have been registered in the container.
 /// So if `a` has a dependency on `b`, this visitor will check if `b` has been registered in the container.
 /// If not, it will emit an error.
-pub struct WiringVisitor {
+pub struct CheckWiring {
     dependencies: Vec<Ident>,
     errors: Vec<Error>,
 }
@@ -20,7 +20,7 @@ struct Error {
     best_match: Option<Ident>,
 }
 
-impl WiringVisitor {
+impl CheckWiring {
     /// Create a new `WiringVisitor` with the given available dependencies.
     /// Ie. if this visitor finds a requested child dependency which is not in the list of available dependencies,
     /// it will emit an error.
@@ -32,7 +32,7 @@ impl WiringVisitor {
     }
 }
 
-impl Visit for WiringVisitor {
+impl Visit for CheckWiring {
     fn visit_child_dependency(&mut self, child_dependency: &ChildDependency) {
         if !self.dependencies.contains(&child_dependency.ident) {
             let best_match =
@@ -86,8 +86,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn misspell() {
-        let mut wiring_visitor = WiringVisitor::new(vec![
+    fn check_wiring() {
+        let mut wiring_visitor = CheckWiring::new(vec![
             Ident::new("foo", proc_macro2::Span::call_site()),
             Ident::new("bar", proc_macro2::Span::call_site()),
             Ident::new("baz", proc_macro2::Span::call_site()),
@@ -102,7 +102,7 @@ mod tests {
 
         wiring_visitor.visit_container(&container);
 
-        let WiringVisitor { errors, .. } = wiring_visitor;
+        let CheckWiring { errors, .. } = wiring_visitor;
 
         assert_eq!(
             errors,

--- a/despatma/src/dependency_container/visitor/check_wiring.rs
+++ b/despatma/src/dependency_container/visitor/check_wiring.rs
@@ -4,7 +4,7 @@ use syn::Ident;
 
 use crate::dependency_container::ChildDependency;
 
-use super::{visit_child_dependency, Visit};
+use super::Visit;
 
 /// This visitor is responsible for checking if all dependencies have been registered in the container.
 /// So if `a` has a dependency on `b`, this visitor will check if `b` has been registered in the container.
@@ -43,22 +43,28 @@ impl Visit for CheckWiring {
                 best_match,
             });
         }
-
-        // Keep traversing the tree
-        visit_child_dependency(self, child_dependency);
     }
 
     fn emit_errors(self) {
         let Self { errors, .. } = self;
 
-        for error in errors {
-            if let Some(best_match) = error.best_match {
-                emit_error!(error.requested, "The '{}' dependency has not been registered", error.requested; hint = best_match.span() => format!("Did you mean `{}`?", best_match));
+        for Error {
+            requested,
+            best_match,
+        } in errors
+        {
+            if let Some(best_match) = best_match {
+                emit_error!(
+                    requested,
+                    "The '{}' dependency has not been registered",
+                    requested;
+                    hint = best_match.span() => format!("Did you mean `{}`?", best_match)
+                );
             } else {
                 emit_error!(
-                    error.requested,
+                    requested,
                     "Dependency not found. Did you forget to add it?";
-                    hint = "Try adding it with `fn {}(&self) ...`", error.requested
+                    hint = "Try adding it with `fn {}(&self) ...`", requested
                 );
             }
         }

--- a/despatma/src/dependency_container/visitor/fix_async_tree.rs
+++ b/despatma/src/dependency_container/visitor/fix_async_tree.rs
@@ -10,12 +10,12 @@ use super::VisitMut;
 /// Visitor used to determine if any child dependencies in the calltree is async. Because if any
 /// child dependencies are async, then the parent dependency must also be async. Which this
 /// visitor updates correcly.
-pub struct AsyncVisitor {
+pub struct FixAsyncTree {
     dependencies: IndexMap<Ident, Rc<RefCell<Dependency>>>,
     visited_dependencies: HashSet<Ident>,
 }
 
-impl AsyncVisitor {
+impl FixAsyncTree {
     pub fn new(dependencies: IndexMap<Ident, Rc<RefCell<Dependency>>>) -> Self {
         Self {
             dependencies,
@@ -24,7 +24,7 @@ impl AsyncVisitor {
     }
 }
 
-impl VisitMut for AsyncVisitor {
+impl VisitMut for FixAsyncTree {
     fn visit_dependency_mut(&mut self, dependency: &mut Dependency) {
         // We want to be efficient and not visit the same dependency multiple times
         if self.visited_dependencies.contains(&dependency.sig.ident) {
@@ -64,7 +64,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn make_async() {
+    fn fix_async_tree() {
         let mut container = Container::from_item_impl(parse_quote!(
             impl Dependencies {
                 fn config(&self) -> Config {
@@ -85,7 +85,7 @@ mod tests {
             }
         ));
 
-        let mut async_visitor = AsyncVisitor::new(container.dependencies.clone());
+        let mut async_visitor = FixAsyncTree::new(container.dependencies.clone());
         async_visitor.visit_container_mut(&mut container);
 
         assert!(

--- a/despatma/src/dependency_container/visitor/impl_trait_but_registered_concrete.rs
+++ b/despatma/src/dependency_container/visitor/impl_trait_but_registered_concrete.rs
@@ -1,0 +1,126 @@
+use std::{cell::RefCell, rc::Rc};
+
+use indexmap::IndexMap;
+use proc_macro_error::emit_error;
+use quote::ToTokens;
+use syn::{Ident, PatType, TypeImplTrait};
+
+use crate::dependency_container::Dependency;
+
+use super::Visit;
+
+/// Visitor to find any requested dependencies of a concrete type, while the registered dependency
+/// returns an `impl Trait`.
+pub struct ImplTraitButRegisteredConcrete {
+    dependencies: IndexMap<Ident, Rc<RefCell<Dependency>>>,
+    errors: Vec<Error>,
+}
+
+#[cfg_attr(test, derive(Eq, PartialEq, Debug))]
+struct Error {
+    requested: PatType,
+    registered: TypeImplTrait,
+}
+
+impl ImplTraitButRegisteredConcrete {
+    pub fn new(dependencies: IndexMap<Ident, Rc<RefCell<Dependency>>>) -> Self {
+        Self {
+            dependencies,
+            errors: Vec::new(),
+        }
+    }
+}
+
+impl Visit for ImplTraitButRegisteredConcrete {
+    fn visit_dependency(&mut self, dependency: &Dependency) {
+        for pat_type in dependency
+            .sig
+            .inputs
+            .iter()
+            .filter_map(|input| match input {
+                syn::FnArg::Receiver(_) => None,
+                syn::FnArg::Typed(pat_type) => match pat_type.ty.as_ref() {
+                    // syn::Type::ImplTrait(impl_trait) => Some(pat_type),
+                    syn::Type::Path(_) => Some(pat_type),
+                    _ => None,
+                },
+            })
+        {
+            let child_ident = match pat_type.pat.as_ref() {
+                syn::Pat::Ident(pat_ident) => pat_ident.ident.clone(),
+                _ => unreachable!("a dependency argument has to be an ident"),
+            };
+
+            if let Some(child_dependency) = self.dependencies.get(&child_ident) {
+                let child_dependency = child_dependency.borrow();
+                let child_return_type = match &child_dependency.sig.output {
+                    // Handled by another validator
+                    syn::ReturnType::Default => continue,
+                    syn::ReturnType::Type(_, ty) => match ty.as_ref() {
+                        syn::Type::ImplTrait(impl_trait) => impl_trait,
+                        _ => continue,
+                    },
+                };
+
+                self.errors.push(Error {
+                    requested: pat_type.clone(),
+                    registered: child_return_type.clone(),
+                });
+            }
+        }
+    }
+
+    fn emit_errors(self) {
+        let errors = self.errors;
+
+        for Error {
+            requested,
+            registered,
+        } in errors
+        {
+            emit_error!(
+                requested,
+                "Requested type is a concrete type, but the registered type is: `{}`",
+                registered.to_token_stream();
+                hint = "change this to `{}: {}`", requested.pat.to_token_stream(), registered.to_token_stream()
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_quote;
+
+    use crate::dependency_container::Container;
+
+    use super::*;
+
+    #[test]
+    fn invalid_case() {
+        let container = Container::from_item_impl(parse_quote!(
+            impl Dependencies {
+                fn db(&self) -> impl DB {
+                    Sqlite
+                }
+
+                fn service(&self, db: Sqlite) -> Service {
+                    Service(db)
+                }
+            }
+        ));
+
+        let mut visitor = ImplTraitButRegisteredConcrete::new(container.dependencies.clone());
+        visitor.visit_container(&container);
+
+        let ImplTraitButRegisteredConcrete { errors, .. } = visitor;
+
+        assert_eq!(
+            errors,
+            vec![Error {
+                requested: parse_quote!(db: Sqlite),
+                registered: parse_quote!(impl DB),
+            }]
+        );
+    }
+}

--- a/despatma/src/dependency_container/visitor/impl_trait_but_registered_concrete.rs
+++ b/despatma/src/dependency_container/visitor/impl_trait_but_registered_concrete.rs
@@ -97,7 +97,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn invalid_case() {
+    fn impl_trait_but_registered_concrete() {
         let container = Container::from_item_impl(parse_quote!(
             impl Dependencies {
                 fn db(&self) -> impl DB {

--- a/despatma/src/dependency_container/visitor/impl_trait_but_registered_concrete.rs
+++ b/despatma/src/dependency_container/visitor/impl_trait_but_registered_concrete.rs
@@ -48,7 +48,7 @@ impl Visit for ImplTraitButRegisteredConcrete {
         {
             let child_ident = match pat_type.pat.as_ref() {
                 syn::Pat::Ident(pat_ident) => pat_ident.ident.clone(),
-                _ => unreachable!("a dependency argument has to be an ident"),
+                _ => continue,
             };
 
             if let Some(child_dependency) = self.dependencies.get(&child_ident) {

--- a/despatma/src/dependency_container/visitor/mod.rs
+++ b/despatma/src/dependency_container/visitor/mod.rs
@@ -1,12 +1,12 @@
 use super::{ChildDependency, Container, Dependency};
 
-mod async_visitor;
+mod check_wiring;
+mod fix_async_tree;
 mod impl_trait_but_registered_concrete;
-mod wiring_visitor;
 
-pub use async_visitor::AsyncVisitor;
+pub use check_wiring::CheckWiring;
+pub use fix_async_tree::FixAsyncTree;
 pub use impl_trait_but_registered_concrete::ImplTraitButRegisteredConcrete;
-pub use wiring_visitor::WiringVisitor;
 
 /// A visitor used to validate the struct that will be turned into a dependency container.
 /// If the visitor found any errors then they should be emit in [emit_errors].

--- a/despatma/src/dependency_container/visitor/mod.rs
+++ b/despatma/src/dependency_container/visitor/mod.rs
@@ -1,9 +1,11 @@
 use super::{ChildDependency, Container, Dependency};
 
 mod async_visitor;
+mod impl_trait_but_registered_concrete;
 mod wiring_visitor;
 
 pub use async_visitor::AsyncVisitor;
+pub use impl_trait_but_registered_concrete::ImplTraitButRegisteredConcrete;
 pub use wiring_visitor::WiringVisitor;
 
 /// A visitor used to validate the struct that will be turned into a dependency container.

--- a/despatma/src/dependency_container/visitor/mod.rs
+++ b/despatma/src/dependency_container/visitor/mod.rs
@@ -1,43 +1,80 @@
 use super::{ChildDependency, Container, Dependency};
 
+mod async_visitor;
 mod wiring_visitor;
 
+pub use async_visitor::AsyncVisitor;
 pub use wiring_visitor::WiringVisitor;
 
 /// A visitor used to validate the struct that will be turned into a dependency container.
-/// If the visitor found any errors then they should be emit in [Drop].
-#[allow(drop_bounds)]
-pub trait MutVisitor: Drop {
+/// If the visitor found any errors then they should be emit in [emit_errors].
+pub trait Visit {
     /// Visit the top level container which will be turned into a struct
     fn visit_container(&mut self, container: &Container) {
-        mut_visit_container(self, container);
+        visit_container(self, container);
     }
 
     /// Visit a dependency that was registered
     fn visit_dependency(&mut self, dependency: &Dependency) {
-        mut_visit_dependency(self, dependency);
+        visit_dependency(self, dependency);
     }
 
     /// Visit a dependency requested by a registered dependency
     fn visit_child_dependency(&mut self, child_dependency: &ChildDependency) {
-        mut_visit_child_dependency(self, child_dependency);
+        visit_child_dependency(self, child_dependency);
     }
+
+    /// Emit any errors that were found during the visit
+    fn emit_errors(self);
 }
 
-fn mut_visit_container<V: MutVisitor + ?Sized>(visitor: &mut V, container: &Container) {
+fn visit_container<V: Visit + ?Sized>(visitor: &mut V, container: &Container) {
     for dependency in container.dependencies.values() {
-        visitor.visit_dependency(dependency);
+        visitor.visit_dependency(&dependency.borrow());
     }
 }
 
-fn mut_visit_dependency<V: MutVisitor + ?Sized>(visitor: &mut V, dependency: &Dependency) {
+fn visit_dependency<V: Visit + ?Sized>(visitor: &mut V, dependency: &Dependency) {
     for child_dependency in &dependency.dependencies {
         visitor.visit_child_dependency(child_dependency);
     }
 }
 
-fn mut_visit_child_dependency<V: MutVisitor + ?Sized>(
+fn visit_child_dependency<V: Visit + ?Sized>(
     _visitor: &mut V,
     _child_dependency: &ChildDependency,
+) {
+}
+
+/// A mutable visitor used to update any dependencies or their children
+pub trait VisitMut {
+    fn visit_container_mut(&mut self, container: &mut Container) {
+        visit_container_mut(self, container);
+    }
+
+    fn visit_dependency_mut(&mut self, dependency: &mut Dependency) {
+        visit_dependency_mut(self, dependency);
+    }
+
+    fn visit_child_dependency_mut(&mut self, child_dependency: &mut ChildDependency) {
+        visit_child_dependency_mut(self, child_dependency);
+    }
+}
+
+fn visit_container_mut<V: VisitMut + ?Sized>(visitor: &mut V, container: &mut Container) {
+    for dependency in container.dependencies.values_mut() {
+        visitor.visit_dependency_mut(&mut dependency.borrow_mut());
+    }
+}
+
+fn visit_dependency_mut<V: VisitMut + ?Sized>(visitor: &mut V, dependency: &mut Dependency) {
+    for child_dependency in &mut dependency.dependencies {
+        visitor.visit_child_dependency_mut(child_dependency);
+    }
+}
+
+fn visit_child_dependency_mut<V: VisitMut + ?Sized>(
+    _visitor: &mut V,
+    _child_dependency: &mut ChildDependency,
 ) {
 }

--- a/despatma/src/dependency_container/visitor/mod.rs
+++ b/despatma/src/dependency_container/visitor/mod.rs
@@ -1,0 +1,43 @@
+use super::{ChildDependency, Container, Dependency};
+
+mod wiring_visitor;
+
+pub use wiring_visitor::WiringVisitor;
+
+/// A visitor used to validate the struct that will be turned into a dependency container.
+/// If the visitor found any errors then they should be emit in [Drop].
+#[allow(drop_bounds)]
+pub trait MutVisitor: Drop {
+    /// Visit the top level container which will be turned into a struct
+    fn visit_container(&mut self, container: &Container) {
+        mut_visit_container(self, container);
+    }
+
+    /// Visit a dependency that was registered
+    fn visit_dependency(&mut self, dependency: &Dependency) {
+        mut_visit_dependency(self, dependency);
+    }
+
+    /// Visit a dependency requested by a registered dependency
+    fn visit_child_dependency(&mut self, child_dependency: &ChildDependency) {
+        mut_visit_child_dependency(self, child_dependency);
+    }
+}
+
+fn mut_visit_container<V: MutVisitor + ?Sized>(visitor: &mut V, container: &Container) {
+    for dependency in container.dependencies.values() {
+        visitor.visit_dependency(dependency);
+    }
+}
+
+fn mut_visit_dependency<V: MutVisitor + ?Sized>(visitor: &mut V, dependency: &Dependency) {
+    for child_dependency in &dependency.dependencies {
+        visitor.visit_child_dependency(child_dependency);
+    }
+}
+
+fn mut_visit_child_dependency<V: MutVisitor + ?Sized>(
+    _visitor: &mut V,
+    _child_dependency: &ChildDependency,
+) {
+}

--- a/despatma/src/dependency_container/visitor/wiring_visitor.rs
+++ b/despatma/src/dependency_container/visitor/wiring_visitor.rs
@@ -11,11 +11,11 @@ use super::{visit_child_dependency, Visit};
 /// If not, it will emit an error.
 pub struct WiringVisitor {
     dependencies: Vec<Ident>,
-    errors: Vec<WiringError>,
+    errors: Vec<Error>,
 }
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
-struct WiringError {
+struct Error {
     requested: Ident,
     best_match: Option<Ident>,
 }
@@ -38,7 +38,7 @@ impl Visit for WiringVisitor {
             let best_match =
                 get_best_dependency_match(&self.dependencies, &child_dependency.ident.to_string());
 
-            self.errors.push(WiringError {
+            self.errors.push(Error {
                 requested: child_dependency.ident.clone(),
                 best_match,
             });
@@ -107,11 +107,11 @@ mod tests {
         assert_eq!(
             errors,
             vec![
-                WiringError {
+                Error {
                     requested: Ident::new("zoo", proc_macro2::Span::call_site()),
                     best_match: Some(Ident::new("foo", proc_macro2::Span::call_site())),
                 },
-                WiringError {
+                Error {
                     requested: Ident::new("barrier", proc_macro2::Span::call_site()),
                     best_match: None,
                 }

--- a/despatma/src/dependency_container/visitor/wiring_visitor.rs
+++ b/despatma/src/dependency_container/visitor/wiring_visitor.rs
@@ -1,0 +1,79 @@
+use proc_macro_error::emit_error;
+use strsim::levenshtein;
+use syn::Ident;
+
+use crate::dependency_container::ChildDependency;
+
+use super::{mut_visit_child_dependency, MutVisitor};
+
+/// This visitor is responsible for checking if all dependencies have been registered in the container.
+/// So if `a` has a dependency on `b`, this visitor will check if `b` has been registered in the container.
+/// If not, it will emit an error.
+pub struct WiringVisitor {
+    dependencies: Vec<Ident>,
+    errors: Vec<WiringError>,
+}
+
+struct WiringError {
+    requested: Ident,
+    best_match: Option<Ident>,
+}
+
+impl WiringVisitor {
+    /// Create a new `WiringVisitor` with the given available dependencies.
+    /// Ie. if this visitor finds a requested child dependency which is not in the list of available dependencies,
+    /// it will emit an error.
+    pub fn new(dependencies: Vec<Ident>) -> Self {
+        Self {
+            dependencies,
+            errors: Vec::new(),
+        }
+    }
+}
+
+impl MutVisitor for WiringVisitor {
+    fn visit_child_dependency(&mut self, child_dependency: &ChildDependency) {
+        if !self.dependencies.contains(&child_dependency.ident) {
+            let best_match =
+                get_best_dependency_match(&self.dependencies, &child_dependency.ident.to_string());
+
+            self.errors.push(WiringError {
+                requested: child_dependency.ident.clone(),
+                best_match,
+            });
+        }
+
+        // Keep traversing the tree
+        mut_visit_child_dependency(self, child_dependency);
+    }
+}
+
+impl Drop for WiringVisitor {
+    fn drop(&mut self) {
+        let Self { errors, .. } = self;
+
+        for error in errors {
+            if let Some(best_match) = &error.best_match {
+                emit_error!(error.requested, "The '{}' dependency has not been registered", error.requested; hint = best_match.span() => format!("Did you mean `{}`?", best_match));
+            } else {
+                emit_error!(
+                    error.requested,
+                    "Dependency not found. Did you forget to add it?";
+                    hint = "Try adding it with `fn {}(&self) ...`", error.requested
+                );
+            }
+        }
+    }
+}
+
+/// The maximum distance between two strings for them to be considered a misspelling.
+const MISSPELLING_THRESHOLD: usize = 3;
+
+fn get_best_dependency_match(dependencies: &Vec<Ident>, needle: &str) -> Option<Ident> {
+    dependencies
+        .iter()
+        .map(|d| (d, levenshtein(&needle.to_string(), &d.to_string())))
+        .filter(|(_, distance)| *distance <= MISSPELLING_THRESHOLD)
+        .min_by_key(|(_, distance)| *distance)
+        .map(|(d, _)| d.clone())
+}

--- a/despatma/src/dependency_container/visitor/wiring_visitor.rs
+++ b/despatma/src/dependency_container/visitor/wiring_visitor.rs
@@ -68,10 +68,10 @@ impl Visit for WiringVisitor {
 /// The maximum distance between two strings for them to be considered a misspelling.
 const MISSPELLING_THRESHOLD: usize = 3;
 
-fn get_best_dependency_match(dependencies: &Vec<Ident>, needle: &str) -> Option<Ident> {
+fn get_best_dependency_match(dependencies: &[Ident], needle: &str) -> Option<Ident> {
     dependencies
         .iter()
-        .map(|d| (d, levenshtein(&needle.to_string(), &d.to_string())))
+        .map(|d| (d, levenshtein(needle, &d.to_string())))
         .filter(|(_, distance)| *distance <= MISSPELLING_THRESHOLD)
         .min_by_key(|(_, distance)| *distance)
         .map(|(d, _)| d.clone())

--- a/despatma/src/lib.rs
+++ b/despatma/src/lib.rs
@@ -3,7 +3,7 @@
 //! [github]: https://img.shields.io/badge/github-8da0cb?style=for-the-badge&labelColor=555555&logo=github
 //! [crates-io]: https://img.shields.io/badge/crates.io-fc8d62?style=for-the-badge&labelColor=555555&logo=rust
 //! [docs-rs]: https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logoColor=white&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K
-//! [workflow]: https://img.shields.io/github/workflow/status/chesedo/despatma/Rust?color=green&label=&labelColor=555555&logo=github%20actions&logoColor=white&style=for-the-badge
+//! [workflow]: https://img.shields.io/github/actions/workflow/status/chesedo/despatma/rust.yml?color=green&label=&labelColor=555555&logo=github%20actions&logoColor=white&style=for-the-badge
 //!
 //! Despatma is a collection of `des`ign `pat`tern `ma`cros (`despatma`).
 //! It aims to provide the most common implementations for design patterns at run-time.
@@ -13,10 +13,12 @@
 //! The following patterns are currently implemented:
 //! - [abstract_factory] - with the help of [interpolate_traits] macro
 //! - [visitor]
+//! - [dependency_container]
 //!
 //! [abstract_factory]: macro@self::abstract_factory
 //! [interpolate_traits]: macro@self::interpolate_traits
 //! [visitor]: macro@self::visitor
+//! [dependency_container]: macro@self::dependency_container
 mod abstract_factory;
 mod dependency_container;
 mod visitor;

--- a/despatma/src/lib.rs
+++ b/despatma/src/lib.rs
@@ -18,13 +18,17 @@
 //! [interpolate_traits]: macro@self::interpolate_traits
 //! [visitor]: macro@self::visitor
 mod abstract_factory;
+mod dependency_container;
 mod visitor;
 
 extern crate proc_macro;
 
+use dependency_container::Container;
 use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
+use quote::quote;
 use syn::punctuated::Punctuated;
-use syn::{parse_macro_input, ItemTrait, Token};
+use syn::{parse_macro_input, ItemImpl, ItemTrait, Token};
 use tokenstream2_tmpl::Interpolate;
 
 use abstract_factory::AbstractFactoryAttribute;
@@ -696,4 +700,18 @@ pub fn visitor(tokens: TokenStream) -> TokenStream {
     let input = parse_macro_input!(tokens as VisitorFunction);
 
     input.expand().into()
+}
+
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn dependency_container(_tokens: TokenStream, impl_expr: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(impl_expr as ItemImpl);
+    let container = Container::from_item_impl(input);
+
+    container.validate();
+
+    quote! {
+        #container
+    }
+    .into()
 }

--- a/despatma/src/lib.rs
+++ b/despatma/src/lib.rs
@@ -706,9 +706,10 @@ pub fn visitor(tokens: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn dependency_container(_tokens: TokenStream, impl_expr: TokenStream) -> TokenStream {
     let input = parse_macro_input!(impl_expr as ItemImpl);
-    let container = Container::from_item_impl(input);
+    let mut container = Container::from_item_impl(input);
 
     container.validate();
+    container.update();
 
     quote! {
         #container

--- a/despatma/tests/expand/dependency_container/async_dep.expanded.rs
+++ b/despatma/tests/expand/dependency_container/async_dep.expanded.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+use tokio::time::sleep;
+struct Config {
+    port: u32,
+}
+struct Service;
+impl Service {
+    fn new(port: u32) -> Self {
+        {
+            ::std::io::_print(format_args!("Async service started on port {0}\n", port));
+        };
+        Self
+    }
+}
+struct DependencyContainer;
+impl DependencyContainer {
+    fn new() -> Self {
+        Self
+    }
+    async fn create_config(&self) -> Config {
+        sleep(Duration::from_millis(10)).await;
+        Config { port: 8080 }
+    }
+    pub async fn config(&self) -> Config {
+        self.create_config().await
+    }
+    fn create_service(&self, config: Config) -> Service {
+        Service::new(config.port)
+    }
+    pub async fn service(&self) -> Service {
+        let config = self.config().await;
+        self.create_service(config)
+    }
+}
+fn main() {
+    let body = async {
+        let container = DependencyContainer::new();
+        let _service = container.service().await;
+    };
+    #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
+    {
+        return tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("Failed building the Runtime")
+            .block_on(body);
+    }
+}

--- a/despatma/tests/expand/dependency_container/async_dep.rs
+++ b/despatma/tests/expand/dependency_container/async_dep.rs
@@ -1,0 +1,33 @@
+use std::time::Duration;
+use tokio::time::sleep;
+
+struct Config {
+    port: u32,
+}
+
+struct Service;
+
+impl Service {
+    fn new(port: u32) -> Self {
+        println!("Async service started on port {}", port);
+        Self
+    }
+}
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    async fn config(&self) -> Config {
+        sleep(Duration::from_millis(10)).await;
+        Config { port: 8080 }
+    }
+
+    fn service(&self, config: Config) -> Service {
+        Service::new(config.port)
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service().await;
+}

--- a/despatma/tests/expand/dependency_container/box_dyn_trait.expanded.rs
+++ b/despatma/tests/expand/dependency_container/box_dyn_trait.expanded.rs
@@ -1,0 +1,56 @@
+use auto_impl::auto_impl;
+struct Config {
+    port: u32,
+}
+trait DAL {}
+const _: () = {
+    extern crate alloc;
+    impl<T: DAL + ?::core::marker::Sized> DAL for alloc::boxed::Box<T> {}
+};
+struct PostgresDAL;
+impl DAL for PostgresDAL {}
+struct SQLiteDAL;
+impl DAL for SQLiteDAL {}
+struct Service<D: DAL> {
+    dal: D,
+}
+impl<D: DAL> Service<D> {
+    fn new(port: u32, dal: D) -> Self {
+        {
+            ::std::io::_print(
+                format_args!("Box dyn Trait service started on port {0}\n", port),
+            );
+        };
+        Self { dal }
+    }
+}
+struct DependencyContainer;
+impl DependencyContainer {
+    fn new() -> Self {
+        Self
+    }
+    fn create_config(&self) -> Config {
+        Config { port: 8080 }
+    }
+    pub fn config(&self) -> Config {
+        self.create_config()
+    }
+    fn create_dal(&self) -> Box<dyn DAL> {
+        if true { Box::new(PostgresDAL) } else { Box::new(SQLiteDAL) }
+    }
+    pub fn dal(&self) -> Box<dyn DAL> {
+        self.create_dal()
+    }
+    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
+        Service::new(config.port, dal)
+    }
+    pub fn service(&self) -> Service<impl DAL> {
+        let config = self.config();
+        let dal = self.dal();
+        self.create_service(config, dal)
+    }
+}
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/box_dyn_trait.rs
+++ b/despatma/tests/expand/dependency_container/box_dyn_trait.rs
@@ -1,0 +1,51 @@
+use auto_impl::auto_impl;
+
+struct Config {
+    port: u32,
+}
+
+#[auto_impl(Box)]
+trait DAL {}
+
+struct PostgresDAL;
+
+impl DAL for PostgresDAL {}
+
+struct SQLiteDAL;
+
+impl DAL for SQLiteDAL {}
+
+struct Service<D: DAL> {
+    dal: D,
+}
+
+impl<D: DAL> Service<D> {
+    fn new(port: u32, dal: D) -> Self {
+        println!("Box dyn Trait service started on port {}", port);
+        Self { dal }
+    }
+}
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    fn config(&self) -> Config {
+        Config { port: 8080 }
+    }
+
+    fn dal(&self) -> Box<dyn DAL> {
+        if true {
+            Box::new(PostgresDAL)
+        } else {
+            Box::new(SQLiteDAL)
+        }
+    }
+
+    fn service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
+        Service::new(config.port, dal)
+    }
+}
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/box_dyn_trait_return_impl.expanded.rs
+++ b/despatma/tests/expand/dependency_container/box_dyn_trait_return_impl.expanded.rs
@@ -1,0 +1,61 @@
+use auto_impl::auto_impl;
+struct Config {
+    port: u32,
+}
+trait DAL {}
+const _: () = {
+    extern crate alloc;
+    impl<T: DAL + ?::core::marker::Sized> DAL for alloc::boxed::Box<T> {}
+};
+struct PostgresDAL;
+impl DAL for PostgresDAL {}
+struct SQLiteDAL;
+impl DAL for SQLiteDAL {}
+struct Service<D: DAL> {
+    dal: D,
+}
+impl<D: DAL> Service<D> {
+    fn new(port: u32, dal: D) -> Self {
+        {
+            ::std::io::_print(
+                format_args!("Box dyn Trait rpit service started on port {0}\n", port),
+            );
+        };
+        Self { dal }
+    }
+}
+struct DependencyContainer;
+impl DependencyContainer {
+    fn new() -> Self {
+        Self
+    }
+    fn create_config(&self) -> Config {
+        Config { port: 8080 }
+    }
+    pub fn config(&self) -> Config {
+        self.create_config()
+    }
+    fn create_dal(&self) -> impl DAL {
+        let d: Box<dyn DAL> = if true {
+            Box::new(PostgresDAL)
+        } else {
+            Box::new(SQLiteDAL)
+        };
+        d
+    }
+    pub fn dal(&self) -> impl DAL {
+        self.create_dal()
+    }
+    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
+        Service::new(config.port, dal)
+    }
+    pub fn service(&self) -> Service<impl DAL> {
+        let config = self.config();
+        let dal = self.dal();
+        self.create_service(config, dal)
+    }
+}
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/box_dyn_trait_return_impl.rs
+++ b/despatma/tests/expand/dependency_container/box_dyn_trait_return_impl.rs
@@ -1,0 +1,53 @@
+use auto_impl::auto_impl;
+
+struct Config {
+    port: u32,
+}
+
+#[auto_impl(Box)]
+trait DAL {}
+
+struct PostgresDAL;
+
+impl DAL for PostgresDAL {}
+
+struct SQLiteDAL;
+
+impl DAL for SQLiteDAL {}
+
+struct Service<D: DAL> {
+    dal: D,
+}
+
+impl<D: DAL> Service<D> {
+    fn new(port: u32, dal: D) -> Self {
+        println!("Box dyn Trait rpit service started on port {}", port);
+        Self { dal }
+    }
+}
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    fn config(&self) -> Config {
+        Config { port: 8080 }
+    }
+
+    fn dal(&self) -> impl DAL {
+        let d: Box<dyn DAL> = if true {
+            Box::new(PostgresDAL)
+        } else {
+            Box::new(SQLiteDAL)
+        };
+
+        d
+    }
+
+    fn service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
+        Service::new(config.port, dal)
+    }
+}
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/documented.expanded.rs
+++ b/despatma/tests/expand/dependency_container/documented.expanded.rs
@@ -1,0 +1,27 @@
+struct Service;
+impl Service {
+    fn new() -> Self {
+        {
+            ::std::io::_print(format_args!("Documented service started\n"));
+        };
+        Self
+    }
+}
+/// A dependency container for the application.
+struct DependencyContainer;
+impl DependencyContainer {
+    fn new() -> Self {
+        Self
+    }
+    fn create_service(&self) -> Service {
+        Service::new()
+    }
+    /// Creates a new instance of the service.
+    pub fn service(&self) -> Service {
+        self.create_service()
+    }
+}
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/documented.rs
+++ b/despatma/tests/expand/dependency_container/documented.rs
@@ -1,0 +1,22 @@
+struct Service;
+
+impl Service {
+    fn new() -> Self {
+        println!("Documented service started");
+        Self
+    }
+}
+
+/// A dependency container for the application.
+#[despatma::dependency_container]
+impl DependencyContainer {
+    /// Creates a new instance of the service.
+    fn service(&self) -> Service {
+        Service::new()
+    }
+}
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/impl_trait_registering_concrete.expanded.rs
+++ b/despatma/tests/expand/dependency_container/impl_trait_registering_concrete.expanded.rs
@@ -1,0 +1,52 @@
+struct Config {
+    port: u32,
+}
+trait DAL {}
+struct PostgresDAL;
+impl DAL for PostgresDAL {}
+struct Service<D: DAL> {
+    dal: D,
+}
+impl<D: DAL> Service<D> {
+    fn new(port: u32, dal: D) -> Self {
+        {
+            ::std::io::_print(
+                format_args!(
+                    "Impl trait but registering concrete service started on port {0}\n",
+                    port,
+                ),
+            );
+        };
+        Self { dal }
+    }
+}
+struct DependencyContainer;
+impl DependencyContainer {
+    fn new() -> Self {
+        Self
+    }
+    fn create_config(&self) -> Config {
+        Config { port: 8080 }
+    }
+    pub fn config(&self) -> Config {
+        self.create_config()
+    }
+    fn create_dal(&self) -> PostgresDAL {
+        PostgresDAL
+    }
+    pub fn dal(&self) -> PostgresDAL {
+        self.create_dal()
+    }
+    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
+        Service::new(config.port, dal)
+    }
+    pub fn service(&self) -> Service<impl DAL> {
+        let config = self.config();
+        let dal = self.dal();
+        self.create_service(config, dal)
+    }
+}
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/impl_trait_registering_concrete.rs
+++ b/despatma/tests/expand/dependency_container/impl_trait_registering_concrete.rs
@@ -1,0 +1,43 @@
+struct Config {
+    port: u32,
+}
+
+trait DAL {}
+
+struct PostgresDAL;
+
+impl DAL for PostgresDAL {}
+
+struct Service<D: DAL> {
+    dal: D,
+}
+
+impl<D: DAL> Service<D> {
+    fn new(port: u32, dal: D) -> Self {
+        println!(
+            "Impl trait but registering concrete service started on port {}",
+            port
+        );
+        Self { dal }
+    }
+}
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    fn config(&self) -> Config {
+        Config { port: 8080 }
+    }
+
+    fn dal(&self) -> PostgresDAL {
+        PostgresDAL
+    }
+
+    fn service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
+        Service::new(config.port, dal)
+    }
+}
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/rpit.expanded.rs
+++ b/despatma/tests/expand/dependency_container/rpit.expanded.rs
@@ -1,0 +1,49 @@
+struct Config {
+    port: u32,
+}
+trait DAL {}
+struct PostgresDAL;
+impl DAL for PostgresDAL {}
+struct Service<D: DAL> {
+    dal: D,
+}
+impl<D: DAL> Service<D> {
+    fn new(port: u32, dal: D) -> Self {
+        {
+            ::std::io::_print(
+                format_args!("Impl trait service started on port {0}\n", port),
+            );
+        };
+        Self { dal }
+    }
+}
+struct DependencyContainer;
+impl DependencyContainer {
+    fn new() -> Self {
+        Self
+    }
+    fn create_config(&self) -> Config {
+        Config { port: 8080 }
+    }
+    pub fn config(&self) -> Config {
+        self.create_config()
+    }
+    fn create_dal(&self) -> impl DAL {
+        PostgresDAL
+    }
+    pub fn dal(&self) -> impl DAL {
+        self.create_dal()
+    }
+    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
+        Service::new(config.port, dal)
+    }
+    pub fn service(&self) -> Service<impl DAL> {
+        let config = self.config();
+        let dal = self.dal();
+        self.create_service(config, dal)
+    }
+}
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/rpit.rs
+++ b/despatma/tests/expand/dependency_container/rpit.rs
@@ -1,0 +1,40 @@
+struct Config {
+    port: u32,
+}
+
+trait DAL {}
+
+struct PostgresDAL;
+
+impl DAL for PostgresDAL {}
+
+struct Service<D: DAL> {
+    dal: D,
+}
+
+impl<D: DAL> Service<D> {
+    fn new(port: u32, dal: D) -> Self {
+        println!("Impl trait service started on port {}", port);
+        Self { dal }
+    }
+}
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    fn config(&self) -> Config {
+        Config { port: 8080 }
+    }
+
+    fn dal(&self) -> impl DAL {
+        PostgresDAL
+    }
+
+    fn service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
+        Service::new(config.port, dal)
+    }
+}
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/simple.expanded.rs
+++ b/despatma/tests/expand/dependency_container/simple.expanded.rs
@@ -29,3 +29,7 @@ impl DependencyContainer {
         self.create_service(config)
     }
 }
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/simple.expanded.rs
+++ b/despatma/tests/expand/dependency_container/simple.expanded.rs
@@ -1,0 +1,31 @@
+struct Config {
+    port: u32,
+}
+struct Service;
+impl Service {
+    fn new(port: u32) -> Self {
+        {
+            ::std::io::_print(format_args!("Service started on port {0}\n", port));
+        };
+        Self
+    }
+}
+struct DependencyContainer;
+impl DependencyContainer {
+    fn new() -> Self {
+        Self
+    }
+    fn create_config(&self) -> Config {
+        Config { port: 8080 }
+    }
+    pub fn config(&self) -> Config {
+        self.create_config()
+    }
+    fn create_service(&self, config: Config) -> Service {
+        Service::new(config.port)
+    }
+    pub fn service(&self) -> Service {
+        let config = self.config();
+        self.create_service(config)
+    }
+}

--- a/despatma/tests/expand/dependency_container/simple.rs
+++ b/despatma/tests/expand/dependency_container/simple.rs
@@ -1,0 +1,23 @@
+struct Config {
+    port: u32,
+}
+
+struct Service;
+
+impl Service {
+    fn new(port: u32) -> Self {
+        println!("Service started on port {}", port);
+        Self
+    }
+}
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    fn config(&self) -> Config {
+        Config { port: 8080 }
+    }
+
+    fn service(&self, config: Config) -> Service {
+        Service::new(config.port)
+    }
+}

--- a/despatma/tests/expand/dependency_container/simple.rs
+++ b/despatma/tests/expand/dependency_container/simple.rs
@@ -21,3 +21,8 @@ impl DependencyContainer {
         Service::new(config.port)
     }
 }
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/expand/dependency_container/simple_reference.expanded.rs
+++ b/despatma/tests/expand/dependency_container/simple_reference.expanded.rs
@@ -1,0 +1,31 @@
+struct Configuration {
+    port: u32,
+}
+struct Task;
+impl Task {
+    fn new(port: u32) -> Self {
+        {
+            ::std::io::_print(format_args!("Task started on port {0}\n", port));
+        };
+        Self
+    }
+}
+struct Dependencies;
+impl Dependencies {
+    fn new() -> Self {
+        Self
+    }
+    fn create_configuration(&self) -> Configuration {
+        Config { port: 8080 }
+    }
+    pub fn configuration(&self) -> Configuration {
+        self.create_configuration()
+    }
+    fn create_task(&self, configuration: &Configuration) -> Task {
+        Task::new(config.port)
+    }
+    pub fn task(&self) -> Task {
+        let configuration = self.configuration();
+        self.create_task(&configuration)
+    }
+}

--- a/despatma/tests/expand/dependency_container/simple_reference.expanded.rs
+++ b/despatma/tests/expand/dependency_container/simple_reference.expanded.rs
@@ -16,16 +16,20 @@ impl Dependencies {
         Self
     }
     fn create_configuration(&self) -> Configuration {
-        Config { port: 8080 }
+        Configuration { port: 8080 }
     }
     pub fn configuration(&self) -> Configuration {
         self.create_configuration()
     }
     fn create_task(&self, configuration: &Configuration) -> Task {
-        Task::new(config.port)
+        Task::new(configuration.port)
     }
     pub fn task(&self) -> Task {
         let configuration = self.configuration();
         self.create_task(&configuration)
     }
+}
+fn main() {
+    let deps = Dependencies::new();
+    let _task = deps.task();
 }

--- a/despatma/tests/expand/dependency_container/simple_reference.rs
+++ b/despatma/tests/expand/dependency_container/simple_reference.rs
@@ -1,0 +1,23 @@
+struct Configuration {
+    port: u32,
+}
+
+struct Task;
+
+impl Task {
+    fn new(port: u32) -> Self {
+        println!("Task started on port {}", port);
+        Self
+    }
+}
+
+#[despatma::dependency_container]
+impl Dependencies {
+    fn configuration(&self) -> Configuration {
+        Config { port: 8080 }
+    }
+
+    fn task(&self, configuration: &Configuration) -> Task {
+        Task::new(config.port)
+    }
+}

--- a/despatma/tests/expand/dependency_container/simple_reference.rs
+++ b/despatma/tests/expand/dependency_container/simple_reference.rs
@@ -14,10 +14,15 @@ impl Task {
 #[despatma::dependency_container]
 impl Dependencies {
     fn configuration(&self) -> Configuration {
-        Config { port: 8080 }
+        Configuration { port: 8080 }
     }
 
     fn task(&self, configuration: &Configuration) -> Task {
-        Task::new(config.port)
+        Task::new(configuration.port)
     }
+}
+
+fn main() {
+    let deps = Dependencies::new();
+    let _task = deps.task();
 }

--- a/despatma/tests/fail/dependency_container/dependency_misspell.rs
+++ b/despatma/tests/fail/dependency_container/dependency_misspell.rs
@@ -18,6 +18,11 @@ impl DependencyContainer {
     }
 
     fn service(&self, canfi: Config) -> Service {
-        Service::new(config.port)
+        Service::new(canfi.port)
     }
+}
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
 }

--- a/despatma/tests/fail/dependency_container/dependency_misspell.rs
+++ b/despatma/tests/fail/dependency_container/dependency_misspell.rs
@@ -1,0 +1,23 @@
+struct Config {
+    port: u32,
+}
+
+struct Service;
+
+impl Service {
+    fn new(port: u32) -> Self {
+        println!("Service started on port {}", port);
+        Self
+    }
+}
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    fn config(&self) -> Config {
+        Config { port: 8080 }
+    }
+
+    fn service(&self, canfi: Config) -> Service {
+        Service::new(config.port)
+    }
+}

--- a/despatma/tests/fail/dependency_container/dependency_misspell.stderr
+++ b/despatma/tests/fail/dependency_container/dependency_misspell.stderr
@@ -1,0 +1,14 @@
+error: The 'canfi' dependency has not been registered
+
+         = help: Did you mean `config`?
+
+  --> tests/fail/dependency_container/dependency_misspell.rs:20:23
+   |
+20 |     fn service(&self, canfi: Config) -> Service {
+   |                       ^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  --> tests/fail/dependency_container/dependency_misspell.rs:23:2
+   |
+23 | }
+   |  ^ consider adding a `main` function to `$DIR/tests/fail/dependency_container/dependency_misspell.rs`

--- a/despatma/tests/fail/dependency_container/dependency_misspell.stderr
+++ b/despatma/tests/fail/dependency_container/dependency_misspell.stderr
@@ -7,8 +7,8 @@ error: The 'canfi' dependency has not been registered
 20 |     fn service(&self, canfi: Config) -> Service {
    |                       ^^^^^
 
-error[E0601]: `main` function not found in crate `$CRATE`
-  --> tests/fail/dependency_container/dependency_misspell.rs:23:2
+error[E0433]: failed to resolve: use of undeclared type `DependencyContainer`
+  --> tests/fail/dependency_container/dependency_misspell.rs:26:21
    |
-23 | }
-   |  ^ consider adding a `main` function to `$DIR/tests/fail/dependency_container/dependency_misspell.rs`
+26 |     let container = DependencyContainer::new();
+   |                     ^^^^^^^^^^^^^^^^^^^ use of undeclared type `DependencyContainer`

--- a/despatma/tests/fail/dependency_container/impl_trait_but_requesting_concrete.rs
+++ b/despatma/tests/fail/dependency_container/impl_trait_but_requesting_concrete.rs
@@ -1,0 +1,40 @@
+struct Config {
+    port: u32,
+}
+
+trait DAL {}
+
+struct PostgresDAL;
+
+impl DAL for PostgresDAL {}
+
+struct Service<D: DAL> {
+    dal: D,
+}
+
+impl<D: DAL> Service<D> {
+    fn new(port: u32, dal: D) -> Self {
+        println!("Impl trait service started on port {}", port);
+        Self { dal }
+    }
+}
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    fn config(&self) -> Config {
+        Config { port: 8080 }
+    }
+
+    fn dal(&self) -> impl DAL {
+        PostgresDAL
+    }
+
+    fn service(&self, config: Config, dal: PostgresDAL) -> Service<PostgresDAL> {
+        Service::new(config.port, dal)
+    }
+}
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/fail/dependency_container/impl_trait_but_requesting_concrete.stderr
+++ b/despatma/tests/fail/dependency_container/impl_trait_but_requesting_concrete.stderr
@@ -1,0 +1,14 @@
+error: Requested type is a concrete type, but the registered type is: `impl DAL`
+
+         = help: change this to `dal: impl DAL`
+
+  --> tests/fail/dependency_container/impl_trait_but_requesting_concrete.rs:32:39
+   |
+32 |     fn service(&self, config: Config, dal: PostgresDAL) -> Service<PostgresDAL> {
+   |                                       ^^^^^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type `DependencyContainer`
+  --> tests/fail/dependency_container/impl_trait_but_requesting_concrete.rs:38:21
+   |
+38 |     let container = DependencyContainer::new();
+   |                     ^^^^^^^^^^^^^^^^^^^ use of undeclared type `DependencyContainer`

--- a/despatma/tests/fail/dependency_container/mismatch_return_type.rs
+++ b/despatma/tests/fail/dependency_container/mismatch_return_type.rs
@@ -1,0 +1,32 @@
+struct Config {
+    port: u32,
+}
+
+struct Unit;
+
+struct Service;
+
+impl Service {
+    fn new(port: u32, _unit: Unit) -> Self {
+        println!("Service started on port {}", port);
+        Self
+    }
+}
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    fn config(&self) -> Config {
+        Config { port: 8080 }
+    }
+
+    fn unit(&self) {}
+
+    fn service(&self, config: u32, unit: Unit) -> Service {
+        Service::new(config, unit)
+    }
+}
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _service = container.service();
+}

--- a/despatma/tests/fail/dependency_container/mismatch_return_type.stderr
+++ b/despatma/tests/fail/dependency_container/mismatch_return_type.stderr
@@ -1,0 +1,13 @@
+error[E0308]: arguments to this method are incorrect
+  --> tests/fail/dependency_container/mismatch_return_type.rs:24:8
+   |
+24 |     fn service(&self, config: u32, unit: Unit) -> Service {
+   |        ^^^^^^^        ------       ---- expected `Unit`, found `()`
+   |                       |
+   |                       expected `u32`, found `Config`
+   |
+note: method defined here
+  --> tests/fail/dependency_container/mismatch_return_type.rs:24:8
+   |
+24 |     fn service(&self, config: u32, unit: Unit) -> Service {
+   |        ^^^^^^^        -----------  ----------

--- a/despatma/tests/fail/dependency_container/unsupported_fn_args.rs
+++ b/despatma/tests/fail/dependency_container/unsupported_fn_args.rs
@@ -1,0 +1,27 @@
+struct Config {
+    port: u32,
+}
+
+struct Service(u32);
+
+struct Task;
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    fn config(&self, x!(): u32, [first, ..]: &[i32], [eerste, tweede]: &[i32; 2]) -> Config {
+        Config { port: 8080 }
+    }
+
+    fn service(&self, Config { port }: Config, (a, b): (i32, i32)) -> Service {
+        Service(port)
+    }
+
+    fn task(&self, Service(port): Service, _: i32) -> Task {
+        Task
+    }
+}
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _config = container.config();
+}

--- a/despatma/tests/fail/dependency_container/unsupported_fn_args.stderr
+++ b/despatma/tests/fail/dependency_container/unsupported_fn_args.stderr
@@ -1,0 +1,47 @@
+error: This argument type is not supported
+  --> tests/fail/dependency_container/unsupported_fn_args.rs:11:22
+   |
+11 |     fn config(&self, x!(): u32, [first, ..]: &[i32], [eerste, tweede]: &[i32; 2]) -> Config {
+   |                      ^^^^
+
+error: This argument type is not supported
+  --> tests/fail/dependency_container/unsupported_fn_args.rs:11:33
+   |
+11 |     fn config(&self, x!(): u32, [first, ..]: &[i32], [eerste, tweede]: &[i32; 2]) -> Config {
+   |                                 ^^^^^^^^^^^
+
+error: This argument type is not supported
+  --> tests/fail/dependency_container/unsupported_fn_args.rs:11:54
+   |
+11 |     fn config(&self, x!(): u32, [first, ..]: &[i32], [eerste, tweede]: &[i32; 2]) -> Config {
+   |                                                      ^^^^^^^^^^^^^^^^
+
+error: This argument type is not supported
+  --> tests/fail/dependency_container/unsupported_fn_args.rs:15:23
+   |
+15 |     fn service(&self, Config { port }: Config, (a, b): (i32, i32)) -> Service {
+   |                       ^^^^^^^^^^^^^^^
+
+error: This argument type is not supported
+  --> tests/fail/dependency_container/unsupported_fn_args.rs:15:48
+   |
+15 |     fn service(&self, Config { port }: Config, (a, b): (i32, i32)) -> Service {
+   |                                                ^^^^^^
+
+error: This argument type is not supported
+  --> tests/fail/dependency_container/unsupported_fn_args.rs:19:20
+   |
+19 |     fn task(&self, Service(port): Service, _: i32) -> Task {
+   |                    ^^^^^^^^^^^^^
+
+error: This argument type is not supported
+  --> tests/fail/dependency_container/unsupported_fn_args.rs:19:44
+   |
+19 |     fn task(&self, Service(port): Service, _: i32) -> Task {
+   |                                            ^
+
+error[E0433]: failed to resolve: use of undeclared type `DependencyContainer`
+  --> tests/fail/dependency_container/unsupported_fn_args.rs:25:21
+   |
+25 |     let container = DependencyContainer::new();
+   |                     ^^^^^^^^^^^^^^^^^^^ use of undeclared type `DependencyContainer`

--- a/despatma/tests/fail/dependency_container/unsupported_impl_types.rs
+++ b/despatma/tests/fail/dependency_container/unsupported_impl_types.rs
@@ -1,0 +1,21 @@
+struct Config {
+    port: u32,
+}
+
+#[despatma::dependency_container]
+impl DependencyContainer {
+    const SIZE: usize = 1;
+
+    type DB = Sqlite;
+
+    db!();
+
+    fn config(&self) -> Config {
+        Config { port: 8080 }
+    }
+}
+
+fn main() {
+    let container = DependencyContainer::new();
+    let _config = container.config();
+}

--- a/despatma/tests/fail/dependency_container/unsupported_impl_types.stderr
+++ b/despatma/tests/fail/dependency_container/unsupported_impl_types.stderr
@@ -1,0 +1,23 @@
+error: This impl item is not supported
+ --> tests/fail/dependency_container/unsupported_impl_types.rs:7:5
+  |
+7 |     const SIZE: usize = 1;
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: This impl item is not supported
+ --> tests/fail/dependency_container/unsupported_impl_types.rs:9:5
+  |
+9 |     type DB = Sqlite;
+  |     ^^^^^^^^^^^^^^^^^
+
+error: This impl item is not supported
+  --> tests/fail/dependency_container/unsupported_impl_types.rs:11:5
+   |
+11 |     db!();
+   |     ^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type `DependencyContainer`
+  --> tests/fail/dependency_container/unsupported_impl_types.rs:19:21
+   |
+19 |     let container = DependencyContainer::new();
+   |                     ^^^^^^^^^^^^^^^^^^^ use of undeclared type `DependencyContainer`

--- a/despatma/tests/tests.rs
+++ b/despatma/tests/tests.rs
@@ -45,5 +45,6 @@ pub fn pass_visitor() {
 pub fn fail() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/fail/abstract_factory/*.rs");
+    t.compile_fail("tests/fail/dependency_container/*.rs");
     t.compile_fail("tests/fail/visitor/*.rs");
 }

--- a/despatma/tests/tests.rs
+++ b/despatma/tests/tests.rs
@@ -28,12 +28,11 @@ pub fn pass_dependency_container() {
         t.pass(path);
     }
 
-    t.pass("tests/expand/dependency_container/*[!.expanded].rs");
     // Get any errors before we run the macrotest
     // Else macrotest might fail and we won't know why
     drop(t);
 
-    // macrotest::expand("tests/expand/dependency_container/*.rs");
+    macrotest::expand("tests/expand/dependency_container/*.rs");
 }
 
 #[test]

--- a/despatma/tests/tests.rs
+++ b/despatma/tests/tests.rs
@@ -4,6 +4,11 @@ pub fn pass_abstract_factory() {
 }
 
 #[test]
+pub fn pass_dependency_container() {
+    macrotest::expand("tests/expand/dependency_container/*.rs");
+}
+
+#[test]
 pub fn pass_visitor() {
     macrotest::expand("tests/expand/visitor/*.rs");
 }

--- a/despatma/tests/tests.rs
+++ b/despatma/tests/tests.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 #[test]
 pub fn pass_abstract_factory() {
     macrotest::expand("tests/expand/abstract_factory/*.rs");
@@ -5,7 +7,33 @@ pub fn pass_abstract_factory() {
 
 #[test]
 pub fn pass_dependency_container() {
-    macrotest::expand("tests/expand/dependency_container/*.rs");
+    let t = trybuild::TestCases::new();
+
+    // Use glob to get all .rs files that don't end with .expanded.rs
+    // These files are used by macrotest
+    let pattern = "tests/expand/dependency_container";
+    for path in fs::read_dir(pattern)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|name| {
+            !name
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .ends_with(".expanded.rs")
+        })
+    {
+        t.pass(path);
+    }
+
+    t.pass("tests/expand/dependency_container/*[!.expanded].rs");
+    // Get any errors before we run the macrotest
+    // Else macrotest might fail and we won't know why
+    drop(t);
+
+    // macrotest::expand("tests/expand/dependency_container/*.rs");
 }
 
 #[test]


### PR DESCRIPTION
This is the first work to automate the creation of dependency containers. The idea is to eventually have the same output as the [manual implementation outlined in my blog](https://chesedo.me/blog/manual-dependency-injection-rust/).

This first implementation just auto wires the dependencies correctly. Ie. it created the public method as outlined in the blog post. Lifetime dependencies are not supported with this commit. Nor are lazy dependencies.