### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 
 [workspace]
 

--- a/despatma-abstract-factory/CHANGELOG.md
+++ b/despatma-abstract-factory/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/despatma-abstract-factory/Cargo.toml
+++ b/despatma-abstract-factory/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["macro", "design", "patterns", "abstract", "factory"]
 proc-macro = true
 
 [dependencies]
-despatma-lib = { version = "0.2.0", path = "../despatma-lib" }
+despatma-lib = { version = "0.3.0", path = "../despatma-lib" }
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["full"] }

--- a/despatma-dependency-container/CHANGELOG.md
+++ b/despatma-dependency-container/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.2.0...despatma-dependency-container-v0.3.0) - 2024-08-15
+
+### Other
+- *(di)* generate the di visitor using our own macro ([#14](https://github.com/chesedo/despatma/pull/14))

--- a/despatma-dependency-container/Cargo.toml
+++ b/despatma-dependency-container/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["design", "patterns", "dependency", "container", "injection"]
 proc-macro = true
 
 [dependencies]
-despatma-visitor = { version = "0.2.0", path = "../despatma-visitor" }
+despatma-visitor = { version = "0.3.0", path = "../despatma-visitor" }
 indexmap = "2.4.0"
 proc-macro-error = "1.0.4"
 proc-macro2.workspace = true

--- a/despatma-lib/CHANGELOG.md
+++ b/despatma-lib/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-lib-v0.2.0...despatma-lib-v0.3.0) - 2024-08-15
+
+### Added
+- [**breaking**] visitor_mut ([#13](https://github.com/chesedo/despatma/pull/13))
+
 ## [0.2.0](https://github.com/chesedo/despatma/compare/despatma-lib-v0.1.1...despatma-lib-v0.2.0) - 2024-08-14
 
 ### Other

--- a/despatma-visitor/CHANGELOG.md
+++ b/despatma-visitor/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-visitor-v0.2.0...despatma-visitor-v0.3.0) - 2024-08-15
+
+### Added
+- [**breaking**] visitor_mut ([#13](https://github.com/chesedo/despatma/pull/13))

--- a/despatma-visitor/Cargo.toml
+++ b/despatma-visitor/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.6.0"
-despatma-lib = { version = "0.2.0", path = "../despatma-lib" }
+despatma-lib = { version = "0.3.0", path = "../despatma-lib" }
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true

--- a/despatma/CHANGELOG.md
+++ b/despatma/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-v0.2.0...despatma-v0.3.0) - 2024-08-15
+
+### Added
+- [**breaking**] visitor_mut ([#13](https://github.com/chesedo/despatma/pull/13))
+
+### Other
+- split into crates ([#10](https://github.com/chesedo/despatma/pull/10))
+
 ## [0.2.0](https://github.com/chesedo/despatma/compare/despatma-v0.1.1...despatma-v0.2.0) - 2024-08-14
 
 ### Added

--- a/despatma/Cargo.toml
+++ b/despatma/Cargo.toml
@@ -9,10 +9,10 @@ license = "MIT"
 keywords = ["macro", "design", "patterns"]
 
 [dependencies]
-despatma-abstract-factory = { version = "0.2.0", path = "../despatma-abstract-factory" }
-despatma-dependency-container = { version = "0.2.0", path = "../despatma-dependency-container" }
-despatma-lib = { version = "0.2.0", path = "../despatma-lib" }
-despatma-visitor = { version = "0.2.0", path = "../despatma-visitor" }
+despatma-abstract-factory = { version = "0.3.0", path = "../despatma-abstract-factory" }
+despatma-dependency-container = { version = "0.3.0", path = "../despatma-dependency-container" }
+despatma-lib = { version = "0.3.0", path = "../despatma-lib" }
+despatma-visitor = { version = "0.3.0", path = "../despatma-visitor" }
 
 [dev-dependencies]
 auto_impl = "1.2.0"


### PR DESCRIPTION
## 🤖 New release
* `despatma`: 0.2.0 -> 0.3.0
* `despatma-abstract-factory`: 0.2.0 -> 0.3.0
* `despatma-lib`: 0.2.0 -> 0.3.0
* `despatma-dependency-container`: 0.2.0 -> 0.3.0
* `despatma-visitor`: 0.2.0 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `despatma`
<blockquote>

## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-v0.2.0...despatma-v0.3.0) - 2024-08-15

### Added
- [**breaking**] visitor_mut ([#13](https://github.com/chesedo/despatma/pull/13))

### Other
- split into crates ([#10](https://github.com/chesedo/despatma/pull/10))
</blockquote>

## `despatma-lib`
<blockquote>

## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-lib-v0.2.0...despatma-lib-v0.3.0) - 2024-08-15

### Added
- [**breaking**] visitor_mut ([#13](https://github.com/chesedo/despatma/pull/13))
</blockquote>

## `despatma-dependency-container`
<blockquote>

## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.2.0...despatma-dependency-container-v0.3.0) - 2024-08-15

### Other
- *(di)* generate the di visitor using our own macro ([#14](https://github.com/chesedo/despatma/pull/14))
</blockquote>

## `despatma-visitor`
<blockquote>

## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-visitor-v0.2.0...despatma-visitor-v0.3.0) - 2024-08-15

### Added
- [**breaking**] visitor_mut ([#13](https://github.com/chesedo/despatma/pull/13))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).