### PR TITLE
chore: release v0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 
 [workspace]
 

--- a/despatma-abstract-factory/CHANGELOG.md
+++ b/despatma-abstract-factory/CHANGELOG.md
@@ -5,3 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-abstract-factory-v0.3.2...despatma-abstract-factory-v0.3.3) - 2024-09-18
+
+### Other
+
+- normalize all line endings ([#21](https://github.com/chesedo/despatma/pull/21))

--- a/despatma-abstract-factory/Cargo.toml
+++ b/despatma-abstract-factory/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["macro", "design", "patterns", "abstract", "factory"]
 proc-macro = true
 
 [dependencies]
-despatma-lib = { version = "0.3.2", path = "../despatma-lib" }
+despatma-lib = { version = "0.3.3", path = "../despatma-lib" }
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["full"] }

--- a/despatma-dependency-container/CHANGELOG.md
+++ b/despatma-dependency-container/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.3.2...despatma-dependency-container-v0.3.3) - 2024-09-18
+
+### Added
+
+- *(di)* Lifetimes support ([#20](https://github.com/chesedo/despatma/pull/20))
+
 ## [0.3.2](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.3.1...despatma-dependency-container-v0.3.2) - 2024-08-16
 
 ### Other

--- a/despatma-dependency-container/Cargo.toml
+++ b/despatma-dependency-container/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["design", "patterns", "dependency", "container", "injection"]
 proc-macro = true
 
 [dependencies]
-despatma-visitor = { version = "0.3.2", path = "../despatma-visitor" }
+despatma-visitor = { version = "0.3.3", path = "../despatma-visitor" }
 proc-macro-error = "1.0.4"
 proc-macro2.workspace = true
 quote.workspace = true

--- a/despatma-visitor/CHANGELOG.md
+++ b/despatma-visitor/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-visitor-v0.3.2...despatma-visitor-v0.3.3) - 2024-09-18
+
+### Other
+
+- normalize all line endings ([#21](https://github.com/chesedo/despatma/pull/21))
+- Update dev env to Rust 1.81.0 ([#22](https://github.com/chesedo/despatma/pull/22))
+
 ## [0.3.1](https://github.com/chesedo/despatma/compare/despatma-visitor-v0.3.0...despatma-visitor-v0.3.1) - 2024-08-16
 
 ### Other

--- a/despatma-visitor/Cargo.toml
+++ b/despatma-visitor/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.6.0"
-despatma-lib = { version = "0.3.2", path = "../despatma-lib" }
+despatma-lib = { version = "0.3.3", path = "../despatma-lib" }
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true

--- a/despatma/CHANGELOG.md
+++ b/despatma/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-v0.3.2...despatma-v0.3.3) - 2024-09-18
+
+### Added
+
+- *(di)* Lifetimes support ([#20](https://github.com/chesedo/despatma/pull/20))
+
 ## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-v0.2.0...despatma-v0.3.0) - 2024-08-15
 
 ### Added

--- a/despatma/Cargo.toml
+++ b/despatma/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["macro", "design", "patterns"]
 
 [dependencies]
 async-once-cell.workspace = true
-despatma-abstract-factory = { version = "0.3.2", path = "../despatma-abstract-factory" }
-despatma-dependency-container = { version = "0.3.2", path = "../despatma-dependency-container", default-features = false }
-despatma-lib = { version = "0.3.2", path = "../despatma-lib" }
-despatma-visitor = { version = "0.3.2", path = "../despatma-visitor" }
+despatma-abstract-factory = { version = "0.3.3", path = "../despatma-abstract-factory" }
+despatma-dependency-container = { version = "0.3.3", path = "../despatma-dependency-container", default-features = false }
+despatma-lib = { version = "0.3.3", path = "../despatma-lib" }
+despatma-visitor = { version = "0.3.3", path = "../despatma-visitor" }
 
 [dev-dependencies]
 auto_impl = "1.2.0"


### PR DESCRIPTION
## 🤖 New release
* `despatma`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `despatma-abstract-factory`: 0.3.2 -> 0.3.3
* `despatma-lib`: 0.3.2 -> 0.3.3
* `despatma-dependency-container`: 0.3.2 -> 0.3.3
* `despatma-visitor`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `despatma`
<blockquote>

## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-v0.3.2...despatma-v0.3.3) - 2024-09-18

### Added

- *(di)* Lifetimes support ([#20](https://github.com/chesedo/despatma/pull/20))
</blockquote>

## `despatma-abstract-factory`
<blockquote>

## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-abstract-factory-v0.3.2...despatma-abstract-factory-v0.3.3) - 2024-09-18

### Other

- normalize all line endings ([#21](https://github.com/chesedo/despatma/pull/21))
</blockquote>

## `despatma-lib`
<blockquote>

## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-lib-v0.2.0...despatma-lib-v0.3.0) - 2024-08-15

### Added
- [**breaking**] visitor_mut ([#13](https://github.com/chesedo/despatma/pull/13))
</blockquote>

## `despatma-dependency-container`
<blockquote>

## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.3.2...despatma-dependency-container-v0.3.3) - 2024-09-18

### Added

- *(di)* Lifetimes support ([#20](https://github.com/chesedo/despatma/pull/20))
</blockquote>

## `despatma-visitor`
<blockquote>

## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-visitor-v0.3.2...despatma-visitor-v0.3.3) - 2024-09-18

### Other

- normalize all line endings ([#21](https://github.com/chesedo/despatma/pull/21))
- Update dev env to Rust 1.81.0 ([#22](https://github.com/chesedo/despatma/pull/22))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).