### PR TITLE
refactor(di): don't generate a private create method

### DIFF
--- a/despatma-dependency-container/src/processing/mod.rs
+++ b/despatma-dependency-container/src/processing/mod.rs
@@ -31,7 +31,6 @@ pub struct Dependency {
     pub(crate) has_explicit_lifetime: bool,
     pub(crate) lifetime: Lifetime,
     pub(crate) ty: Type,
-    pub(crate) create_ty: Type,
     pub(crate) field_ty: Option<Type>,
     pub(crate) dependencies: Vec<ChildDependency>,
 }
@@ -108,8 +107,6 @@ impl From<ImplItemFn> for Dependency {
             ReturnType::Default => parse_quote! { () },
         };
 
-        let create_ty = ty.clone();
-
         Self {
             attrs,
             sig,
@@ -119,7 +116,6 @@ impl From<ImplItemFn> for Dependency {
             has_explicit_lifetime: false,
             lifetime: Lifetime::Transient,
             ty,
-            create_ty,
             field_ty: None,
             dependencies: vec![],
         }

--- a/despatma-dependency-container/src/processing/visitor/extract_box_type.rs
+++ b/despatma-dependency-container/src/processing/visitor/extract_box_type.rs
@@ -36,7 +36,6 @@ impl VisitorMut for ExtractBoxType {
         };
 
         dependency.is_boxed = true;
-        dependency.create_ty = ty.clone();
         dependency.ty = ty.clone();
     }
 }
@@ -79,17 +78,9 @@ mod tests {
             container.dependencies[0].borrow().ty,
             parse_quote!(Box<dyn DAL>),
         );
-        assert_eq!(
-            container.dependencies[0].borrow().create_ty,
-            parse_quote!(Box<dyn DAL>),
-        );
         assert!(!container.dependencies[1].borrow().is_boxed);
         assert_eq!(
             container.dependencies[1].borrow().ty,
-            parse_quote!(std::boxed::Box<dyn DAL>),
-        );
-        assert_eq!(
-            container.dependencies[1].borrow().create_ty,
             parse_quote!(std::boxed::Box<dyn DAL>),
         );
 
@@ -97,15 +88,7 @@ mod tests {
 
         assert!(container.dependencies[0].borrow().is_boxed);
         assert_eq!(container.dependencies[0].borrow().ty, parse_quote!(dyn DAL));
-        assert_eq!(
-            container.dependencies[0].borrow().create_ty,
-            parse_quote!(dyn DAL)
-        );
         assert!(container.dependencies[1].borrow().is_boxed);
         assert_eq!(container.dependencies[1].borrow().ty, parse_quote!(dyn DAL));
-        assert_eq!(
-            container.dependencies[1].borrow().create_ty,
-            parse_quote!(dyn DAL)
-        );
     }
 }

--- a/despatma-dependency-container/src/processing/visitor/wrap_box_type.rs
+++ b/despatma-dependency-container/src/processing/visitor/wrap_box_type.rs
@@ -13,7 +13,6 @@ impl VisitorMut for WrapBoxType {
     fn visit_dependency_mut(&mut self, dependency: &mut Dependency) {
         if dependency.is_boxed {
             let ty = &dependency.ty;
-            dependency.create_ty = parse_quote!(std::boxed::Box<#ty>);
 
             if dependency.has_explicit_lifetime {
                 dependency.field_ty = Some(parse_quote!(std::boxed::Box<#ty + 'a>));
@@ -73,27 +72,15 @@ mod tests {
         assert!(container.dependencies[0].borrow().has_explicit_lifetime);
         assert_eq!(container.dependencies[0].borrow().ty, parse_quote!(dyn DAL));
         assert_eq!(
-            container.dependencies[0].borrow().create_ty,
-            parse_quote!(dyn DAL)
-        );
-        assert_eq!(
             container.dependencies[0].borrow().field_ty,
             Some(parse_quote!(dyn DAL))
         );
         assert!(!container.dependencies[1].borrow().has_explicit_lifetime);
         assert_eq!(container.dependencies[1].borrow().ty, parse_quote!(Utc));
-        assert_eq!(
-            container.dependencies[1].borrow().create_ty,
-            parse_quote!(Utc)
-        );
         assert_eq!(container.dependencies[1].borrow().field_ty, None);
         assert!(!container.dependencies[2].borrow().has_explicit_lifetime);
         assert_eq!(
             container.dependencies[2].borrow().ty,
-            parse_quote!(Service<impl DAL>),
-        );
-        assert_eq!(
-            container.dependencies[2].borrow().create_ty,
             parse_quote!(Service<impl DAL>),
         );
         assert_eq!(container.dependencies[2].borrow().field_ty, None);
@@ -105,10 +92,6 @@ mod tests {
             parse_quote!(std::boxed::Box<dyn DAL + 'a>),
         );
         assert_eq!(
-            container.dependencies[0].borrow().create_ty,
-            parse_quote!(std::boxed::Box<dyn DAL>),
-        );
-        assert_eq!(
             container.dependencies[0].borrow().field_ty,
             Some(parse_quote!(std::boxed::Box<dyn DAL + 'a>))
         );
@@ -116,17 +99,9 @@ mod tests {
             container.dependencies[1].borrow().ty,
             parse_quote!(std::boxed::Box<Utc>),
         );
-        assert_eq!(
-            container.dependencies[1].borrow().create_ty,
-            parse_quote!(std::boxed::Box<Utc>),
-        );
         assert_eq!(container.dependencies[1].borrow().field_ty, None);
         assert_eq!(
             container.dependencies[2].borrow().ty,
-            parse_quote!(Service<impl DAL>),
-        );
-        assert_eq!(
-            container.dependencies[2].borrow().create_ty,
             parse_quote!(Service<impl DAL>),
         );
         assert_eq!(container.dependencies[2].borrow().field_ty, None);

--- a/despatma-dependency-container/tests/expand/async-singleton-dependency.expanded.rs
+++ b/despatma-dependency-container/tests/expand/async-singleton-dependency.expanded.rs
@@ -31,19 +31,19 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    async fn create_config(&self) -> Config {
-        sleep(Duration::from_millis(10)).await;
-        Config { port: 8080 }
-    }
     pub async fn config(&self) -> &Config {
-        self.config.get_or_init(self.create_config()).await
-    }
-    fn create_service(&self, config: &Config) -> Service {
-        Service::new(config.port)
+        self.config
+            .get_or_init(async {
+                {
+                    sleep(Duration::from_millis(10)).await;
+                    Config { port: 8080 }
+                }
+            })
+            .await
     }
     pub async fn service(&self) -> Service {
         let config = self.config().await;
-        self.create_service(config)
+        { Service::new(config.port) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/async_dep.expanded.rs
+++ b/despatma-dependency-container/tests/expand/async_dep.expanded.rs
@@ -26,19 +26,15 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    async fn create_config(&self) -> Config {
-        sleep(Duration::from_millis(10)).await;
-        Config { port: 8080 }
-    }
     pub async fn config(&self) -> Config {
-        self.create_config().await
-    }
-    fn create_service(&self, config: Config) -> Service {
-        Service::new(config.port)
+        {
+            sleep(Duration::from_millis(10)).await;
+            Config { port: 8080 }
+        }
     }
     pub async fn service(&self) -> Service {
         let config = self.config().await;
-        self.create_service(config)
+        { Service::new(config.port) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/box_dyn_trait.expanded.rs
+++ b/despatma-dependency-container/tests/expand/box_dyn_trait.expanded.rs
@@ -38,25 +38,16 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_config(&self) -> Config {
-        Config { port: 8080 }
-    }
     pub fn config(&self) -> Config {
-        self.create_config()
-    }
-    fn create_dal(&self) -> std::boxed::Box<dyn DAL> {
-        if true { Box::new(PostgresDAL) } else { Box::new(SQLiteDAL) }
+        { Config { port: 8080 } }
     }
     pub fn dal(&self) -> std::boxed::Box<dyn DAL> {
-        self.create_dal()
-    }
-    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
-        Service::new(config.port, dal)
+        { if true { Box::new(PostgresDAL) } else { Box::new(SQLiteDAL) } }
     }
     pub fn service(&self) -> Service<impl DAL> {
         let config = self.config();
         let dal = self.dal();
-        self.create_service(config, dal)
+        { Service::new(config.port, dal) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/box_dyn_trait_return_impl.expanded.rs
+++ b/despatma-dependency-container/tests/expand/box_dyn_trait_return_impl.expanded.rs
@@ -38,30 +38,23 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_config(&self) -> Config {
-        Config { port: 8080 }
-    }
     pub fn config(&self) -> Config {
-        self.create_config()
-    }
-    fn create_dal(&self) -> impl DAL {
-        let d: Box<dyn DAL> = if true {
-            Box::new(PostgresDAL)
-        } else {
-            Box::new(SQLiteDAL)
-        };
-        d
+        { Config { port: 8080 } }
     }
     pub fn dal(&self) -> impl DAL {
-        self.create_dal()
-    }
-    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
-        Service::new(config.port, dal)
+        {
+            let d: Box<dyn DAL> = if true {
+                Box::new(PostgresDAL)
+            } else {
+                Box::new(SQLiteDAL)
+            };
+            d
+        }
     }
     pub fn service(&self) -> Service<impl DAL> {
         let config = self.config();
         let dal = self.dal();
-        self.create_service(config, dal)
+        { Service::new(config.port, dal) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/documented.expanded.rs
+++ b/despatma-dependency-container/tests/expand/documented.expanded.rs
@@ -22,12 +22,9 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_service(&self) -> Service {
-        Service::new()
-    }
     /// Creates a new instance of the service.
     pub fn service(&self) -> Service {
-        self.create_service()
+        { Service::new() }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/impl_trait_registering_concrete.expanded.rs
+++ b/despatma-dependency-container/tests/expand/impl_trait_registering_concrete.expanded.rs
@@ -34,25 +34,16 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_config(&self) -> Config {
-        Config { port: 8080 }
-    }
     pub fn config(&self) -> Config {
-        self.create_config()
-    }
-    fn create_dal(&self) -> PostgresDAL {
-        PostgresDAL
+        { Config { port: 8080 } }
     }
     pub fn dal(&self) -> PostgresDAL {
-        self.create_dal()
-    }
-    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
-        Service::new(config.port, dal)
+        { PostgresDAL }
     }
     pub fn service(&self) -> Service<impl DAL> {
         let config = self.config();
         let dal = self.dal();
-        self.create_service(config, dal)
+        { Service::new(config.port, dal) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/rpit.expanded.rs
+++ b/despatma-dependency-container/tests/expand/rpit.expanded.rs
@@ -31,25 +31,16 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_config(&self) -> Config {
-        Config { port: 8080 }
-    }
     pub fn config(&self) -> Config {
-        self.create_config()
-    }
-    fn create_dal(&self) -> impl DAL {
-        PostgresDAL
+        { Config { port: 8080 } }
     }
     pub fn dal(&self) -> impl DAL {
-        self.create_dal()
-    }
-    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
-        Service::new(config.port, dal)
+        { PostgresDAL }
     }
     pub fn service(&self) -> Service<impl DAL> {
         let config = self.config();
         let dal = self.dal();
-        self.create_service(config, dal)
+        { Service::new(config.port, dal) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/scoped-lifetime.expanded.rs
+++ b/despatma-dependency-container/tests/expand/scoped-lifetime.expanded.rs
@@ -29,18 +29,12 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_config(&self) -> Config {
-        Config { port: 8080 }
-    }
     pub fn config(&self) -> &Config {
-        self.config.get_or_init(|| self.create_config())
-    }
-    fn create_service(&self, config: &Config) -> Service {
-        Service::new(config.port)
+        self.config.get_or_init(|| { Config { port: 8080 } })
     }
     pub fn service(&self) -> Service {
         let config = self.config();
-        self.create_service(config)
+        { Service::new(config.port) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/simple.expanded.rs
+++ b/despatma-dependency-container/tests/expand/simple.expanded.rs
@@ -24,18 +24,12 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_config(&self) -> Config {
-        Config { port: 8080 }
-    }
     pub fn config(&self) -> Config {
-        self.create_config()
-    }
-    fn create_service(&self, config: Config) -> Service {
-        Service::new(config.port)
+        { Config { port: 8080 } }
     }
     pub fn service(&self) -> Service {
         let config = self.config();
-        self.create_service(config)
+        { Service::new(config.port) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/simple_reference.expanded.rs
+++ b/despatma-dependency-container/tests/expand/simple_reference.expanded.rs
@@ -24,18 +24,12 @@ impl<'a> Dependencies<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_configuration(&self) -> Configuration {
-        Configuration { port: 8080 }
-    }
     pub fn configuration(&self) -> Configuration {
-        self.create_configuration()
-    }
-    fn create_task(&self, configuration: &Configuration) -> Task {
-        Task::new(configuration.port)
+        { Configuration { port: 8080 } }
     }
     pub fn task(&self) -> Task {
         let configuration = self.configuration();
-        self.create_task(&configuration)
+        { Task::new(configuration.port) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/singleton-lifetime-box-dyn-trait.expanded.rs
+++ b/despatma-dependency-container/tests/expand/singleton-lifetime-box-dyn-trait.expanded.rs
@@ -47,25 +47,19 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_config(&self) -> Config {
-        Config { port: 8080 }
-    }
     pub fn config(&self) -> Config {
-        self.create_config()
-    }
-    fn create_dal(&self) -> std::boxed::Box<dyn DAL> {
-        if true { Box::new(PostgresDAL) } else { Box::new(SQLiteDAL) }
+        { Config { port: 8080 } }
     }
     pub fn dal(&self) -> &std::boxed::Box<dyn DAL + 'a> {
-        self.dal.get_or_init(|| self.create_dal())
-    }
-    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
-        Service::new(config.port, dal)
+        self.dal
+            .get_or_init(|| {
+                if true { Box::new(PostgresDAL) } else { Box::new(SQLiteDAL) }
+            })
     }
     pub fn service(&self) -> Service<impl DAL + '_> {
         let config = self.config();
         let dal = self.dal();
-        self.create_service(config, dal)
+        { Service::new(config.port, dal) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/singleton-lifetime-impl-trait-with-box.expanded.rs
+++ b/despatma-dependency-container/tests/expand/singleton-lifetime-impl-trait-with-box.expanded.rs
@@ -47,25 +47,19 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_config(&self) -> Config {
-        Config { port: 8080 }
-    }
     pub fn config(&self) -> Config {
-        self.create_config()
-    }
-    fn create_dal(&self) -> Box<dyn DAL> {
-        if true { Box::new(PostgresDAL) } else { Box::new(SQLiteDAL) }
+        { Config { port: 8080 } }
     }
     pub fn dal(&self) -> &impl DAL {
-        self.dal.get_or_init(|| self.create_dal())
-    }
-    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
-        Service::new(config.port, dal)
+        self.dal
+            .get_or_init(|| {
+                if true { Box::new(PostgresDAL) } else { Box::new(SQLiteDAL) }
+            })
     }
     pub fn service(&self) -> Service<impl DAL + '_> {
         let config = self.config();
         let dal = self.dal();
-        self.create_service(config, dal)
+        { Service::new(config.port, dal) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/singleton-lifetime-impl-trait.expanded.rs
+++ b/despatma-dependency-container/tests/expand/singleton-lifetime-impl-trait.expanded.rs
@@ -40,25 +40,16 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_config(&self) -> Config {
-        Config { port: 8080 }
-    }
     pub fn config(&self) -> Config {
-        self.create_config()
-    }
-    fn create_dal(&self) -> PostgresDAL {
-        PostgresDAL
+        { Config { port: 8080 } }
     }
     pub fn dal(&self) -> &impl DAL {
-        self.dal.get_or_init(|| self.create_dal())
-    }
-    fn create_service(&self, config: Config, dal: impl DAL) -> Service<impl DAL> {
-        Service::new(config.port, dal)
+        self.dal.get_or_init(|| { PostgresDAL })
     }
     pub fn service(&self) -> Service<impl DAL + '_> {
         let config = self.config();
         let dal = self.dal();
-        self.create_service(config, dal)
+        { Service::new(config.port, dal) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/singleton-lifetime.expanded.rs
+++ b/despatma-dependency-container/tests/expand/singleton-lifetime.expanded.rs
@@ -29,18 +29,12 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_config(&self) -> Config {
-        Config { port: 8080 }
-    }
     pub fn config(&self) -> &Config {
-        self.config.get_or_init(|| self.create_config())
-    }
-    fn create_service(&self, config: &Config) -> Service {
-        Service::new(config.port)
+        self.config.get_or_init(|| { Config { port: 8080 } })
     }
     pub fn service(&self) -> Service {
         let config = self.config();
-        self.create_service(config)
+        { Service::new(config.port) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/expand/trailing_comma.expanded.rs
+++ b/despatma-dependency-container/tests/expand/trailing_comma.expanded.rs
@@ -28,29 +28,16 @@ impl<'a> DependencyContainer<'a> {
             _phantom: Default::default(),
         }
     }
-    fn create_configuration(&self) -> Configuration {
-        Configuration { port: 8080 }
-    }
     pub fn configuration(&self) -> Configuration {
-        self.create_configuration()
-    }
-    fn create_my_data_layer_over_socket(&self) -> MyDataLayerOverSocket {
-        MyDataLayerOverSocket
+        { Configuration { port: 8080 } }
     }
     pub fn my_data_layer_over_socket(&self) -> MyDataLayerOverSocket {
-        self.create_my_data_layer_over_socket()
-    }
-    fn create_service(
-        &self,
-        configuration: Configuration,
-        my_data_layer_over_socket: MyDataLayerOverSocket,
-    ) -> Service {
-        Service::new(configuration.port, my_data_layer_over_socket)
+        { MyDataLayerOverSocket }
     }
     pub fn service(&self) -> Service {
         let configuration = self.configuration();
         let my_data_layer_over_socket = self.my_data_layer_over_socket();
-        self.create_service(configuration, my_data_layer_over_socket)
+        { Service::new(configuration.port, my_data_layer_over_socket) }
     }
 }
 fn main() {

--- a/despatma-dependency-container/tests/fail/mismatch_return_type.stderr
+++ b/despatma-dependency-container/tests/fail/mismatch_return_type.stderr
@@ -1,17 +1,13 @@
-error[E0308]: arguments to this method are incorrect
-  --> tests/fail/mismatch_return_type.rs:24:8
+error[E0308]: arguments to this function are incorrect
+  --> tests/fail/mismatch_return_type.rs:25:9
    |
-18 |     fn config(&self) -> Config {
-   |        ------ expected `u32`, found `Config`
-...
-22 |     fn unit(&self) {}
-   |        ---- expected `Unit`, found `()`
-23 |
-24 |     fn service(&self, config: u32, unit: Unit) -> Service {
-   |        ^^^^^^^
+25 |         Service::new(config, unit)
+   |         ^^^^^^^^^^^^ ------  ---- expected `Unit`, found `()`
+   |                      |
+   |                      expected `u32`, found `Config`
    |
-note: method defined here
-  --> tests/fail/mismatch_return_type.rs:24:8
+note: associated function defined here
+  --> tests/fail/mismatch_return_type.rs:10:8
    |
-24 |     fn service(&self, config: u32, unit: Unit) -> Service {
-   |        ^^^^^^^        -----------  ----------
+10 |     fn new(port: u32, _unit: Unit) -> Self {
+   |        ^^^ ---------  -----------


### PR DESCRIPTION
This method was originally used to make it easier to make child dependencies. However, it has become a fight with the compiler.