### PR TITLE
chore: release v0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "despatma"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-once-cell",
  "auto_impl",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "despatma-abstract-factory"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "despatma-lib",
  "despatma-test-helpers",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "despatma-dependency-container"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-once-cell",
  "auto_impl",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "despatma-lib"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "despatma-test-helpers",
  "pretty_assertions",
@@ -126,14 +126,14 @@ dependencies = [
 
 [[package]]
 name = "despatma-test-helpers"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "despatma-visitor"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "convert_case",
  "despatma-lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 
 [workspace]
 members = [

--- a/despatma-abstract-factory/Cargo.toml
+++ b/despatma-abstract-factory/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["macro", "design", "patterns", "abstract", "factory"]
 proc-macro = true
 
 [dependencies]
-despatma-lib = { version = "0.3.5", path = "../despatma-lib" }
+despatma-lib = { version = "0.3.6", path = "../despatma-lib" }
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["full"] }

--- a/despatma-dependency-container/CHANGELOG.md
+++ b/despatma-dependency-container/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.3.5...despatma-dependency-container-v0.3.6) - 2025-03-07
+
+### Other
+
+- dependencies updates ([#36](https://github.com/chesedo/despatma/pull/36))
+
 ## [0.3.5](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.3.4...despatma-dependency-container-v0.3.5) - 2024-11-06
 
 ### Added

--- a/despatma-dependency-container/Cargo.toml
+++ b/despatma-dependency-container/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["design", "patterns", "dependency", "container", "injection"]
 proc-macro = true
 
 [dependencies]
-despatma-visitor = { version = "0.3.5", path = "../despatma-visitor" }
+despatma-visitor = { version = "0.3.6", path = "../despatma-visitor" }
 proc-macro-error2 = "2.0.0"
 proc-macro2.workspace = true
 quote.workspace = true

--- a/despatma-visitor/CHANGELOG.md
+++ b/despatma-visitor/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/chesedo/despatma/compare/despatma-visitor-v0.3.5...despatma-visitor-v0.3.6) - 2025-03-07
+
+### Other
+
+- dependencies updates ([#36](https://github.com/chesedo/despatma/pull/36))
+
 ## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-visitor-v0.3.2...despatma-visitor-v0.3.3) - 2024-09-18
 
 ### Other

--- a/despatma-visitor/Cargo.toml
+++ b/despatma-visitor/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.8.0"
-despatma-lib = { version = "0.3.5", path = "../despatma-lib" }
+despatma-lib = { version = "0.3.6", path = "../despatma-lib" }
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true

--- a/despatma/Cargo.toml
+++ b/despatma/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["macro", "design", "patterns"]
 
 [dependencies]
 async-once-cell.workspace = true
-despatma-abstract-factory = { version = "0.3.5", path = "../despatma-abstract-factory" }
-despatma-dependency-container = { version = "0.3.5", path = "../despatma-dependency-container", default-features = false }
-despatma-lib = { version = "0.3.5", path = "../despatma-lib" }
-despatma-visitor = { version = "0.3.5", path = "../despatma-visitor" }
+despatma-abstract-factory = { version = "0.3.6", path = "../despatma-abstract-factory" }
+despatma-dependency-container = { version = "0.3.6", path = "../despatma-dependency-container", default-features = false }
+despatma-lib = { version = "0.3.6", path = "../despatma-lib" }
+despatma-visitor = { version = "0.3.6", path = "../despatma-visitor" }
 
 [dev-dependencies]
 auto_impl = "1.2.0"


### PR DESCRIPTION



## 🤖 New release

* `despatma-lib`: 0.3.5 -> 0.3.6
* `despatma-abstract-factory`: 0.3.5 -> 0.3.6
* `despatma-visitor`: 0.3.5 -> 0.3.6
* `despatma-dependency-container`: 0.3.5 -> 0.3.6
* `despatma`: 0.3.5 -> 0.3.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `despatma-lib`

<blockquote>

## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-lib-v0.2.0...despatma-lib-v0.3.0) - 2024-08-15

### Added
- [**breaking**] visitor_mut ([#13](https://github.com/chesedo/despatma/pull/13))
</blockquote>

## `despatma-abstract-factory`

<blockquote>

## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-abstract-factory-v0.3.2...despatma-abstract-factory-v0.3.3) - 2024-09-18

### Other

- normalize all line endings ([#21](https://github.com/chesedo/despatma/pull/21))
</blockquote>

## `despatma-visitor`

<blockquote>

## [0.3.6](https://github.com/chesedo/despatma/compare/despatma-visitor-v0.3.5...despatma-visitor-v0.3.6) - 2025-03-07

### Other

- dependencies updates ([#36](https://github.com/chesedo/despatma/pull/36))
</blockquote>

## `despatma-dependency-container`

<blockquote>

## [0.3.6](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.3.5...despatma-dependency-container-v0.3.6) - 2025-03-07

### Other

- dependencies updates ([#36](https://github.com/chesedo/despatma/pull/36))
</blockquote>

## `despatma`

<blockquote>

## [0.3.4](https://github.com/chesedo/despatma/compare/despatma-v0.3.3...despatma-v0.3.4) - 2024-09-24

### Added

- *(di)* nested impl traits ([#31](https://github.com/chesedo/despatma/pull/31))

### Other

- example for using dependency_container ([#27](https://github.com/chesedo/despatma/pull/27))
- dev experience ([#24](https://github.com/chesedo/despatma/pull/24))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).