### PR TITLE
feat(di): Allow changing the visibility of the generated dependency container

### DIFF
--- a/despatma-dependency-container/src/input.rs
+++ b/despatma-dependency-container/src/input.rs
@@ -1,8 +1,9 @@
 use proc_macro_error2::emit_error;
-use syn::{Attribute, ImplItem, ImplItemFn, ItemImpl, Type};
+use syn::{Attribute, ImplItem, ImplItemFn, ItemImpl, Type, Visibility};
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct Container {
+    pub(crate) vis: Visibility,
     pub(crate) attrs: Vec<Attribute>,
     pub(crate) self_ty: Type,
     pub(crate) dependencies: Vec<ImplItemFn>,
@@ -23,10 +24,15 @@ impl Container {
             .collect();
 
         Self {
+            vis: Visibility::Inherited,
             attrs: item_impl.attrs,
             self_ty: item_impl.self_ty.as_ref().clone(),
             dependencies,
         }
+    }
+
+    pub fn set_visibility(&mut self, vis: Visibility) {
+        self.vis = vis;
     }
 }
 
@@ -78,6 +84,7 @@ mod tests {
             }
         ));
         let expected = Container {
+            vis: Visibility::Inherited,
             attrs: vec![],
             self_ty: parse_quote!(DependencyContainer),
             dependencies: vec![

--- a/despatma-dependency-container/src/lib.rs
+++ b/despatma-dependency-container/src/lib.rs
@@ -11,9 +11,13 @@ mod processing;
 
 #[proc_macro_error]
 #[proc_macro_attribute]
-pub fn dependency_container(_tokens: TokenStream, impl_expr: TokenStream) -> TokenStream {
+pub fn dependency_container(tokens: TokenStream, impl_expr: TokenStream) -> TokenStream {
     let input = parse_macro_input!(impl_expr as ItemImpl);
-    let input = input::Container::from_item_impl(input);
+    let mut input = input::Container::from_item_impl(input);
+
+    let visibility = parse_macro_input!(tokens as syn::Visibility);
+    input.set_visibility(visibility);
+
     let mut processing: processing::Container = input.into();
     processing.process();
     let output: output::Container = processing.into();

--- a/despatma-dependency-container/src/processing/mod.rs
+++ b/despatma-dependency-container/src/processing/mod.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, rc::Rc};
 
 use proc_macro2::Span;
-use syn::{parse_quote, Attribute, Block, ImplItemFn, ReturnType, Signature, Type};
+use syn::{parse_quote, Attribute, Block, ImplItemFn, ReturnType, Signature, Type, Visibility};
 
 use crate::input;
 
@@ -15,6 +15,7 @@ mod visitor;
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct Container {
+    pub(crate) vis: Visibility,
     pub(crate) attrs: Vec<Attribute>,
     pub(crate) self_ty: Type,
     pub(crate) dependencies: Vec<Rc<RefCell<Dependency>>>,
@@ -72,6 +73,7 @@ impl Lifetime {
 impl From<input::Container> for Container {
     fn from(input: input::Container) -> Self {
         let input::Container {
+            vis,
             attrs,
             self_ty,
             dependencies,
@@ -85,6 +87,7 @@ impl From<input::Container> for Container {
             .collect();
 
         Self {
+            vis,
             attrs,
             self_ty,
             dependencies,

--- a/despatma-dependency-container/tests/expand/visibility.expanded.rs
+++ b/despatma-dependency-container/tests/expand/visibility.expanded.rs
@@ -1,0 +1,150 @@
+//! Test all the visibility levels of generated dependency containers.
+struct PrivateDependencyContainer<'a> {
+    _phantom: std::marker::PhantomData<&'a ()>,
+}
+#[automatically_derived]
+impl<'a> ::core::clone::Clone for PrivateDependencyContainer<'a> {
+    #[inline]
+    fn clone(&self) -> PrivateDependencyContainer<'a> {
+        PrivateDependencyContainer {
+            _phantom: ::core::clone::Clone::clone(&self._phantom),
+        }
+    }
+}
+impl<'a> PrivateDependencyContainer<'a> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+    pub fn new_scope(&self) -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+}
+pub struct PublicDependencyContainer<'a> {
+    _phantom: std::marker::PhantomData<&'a ()>,
+}
+#[automatically_derived]
+impl<'a> ::core::clone::Clone for PublicDependencyContainer<'a> {
+    #[inline]
+    fn clone(&self) -> PublicDependencyContainer<'a> {
+        PublicDependencyContainer {
+            _phantom: ::core::clone::Clone::clone(&self._phantom),
+        }
+    }
+}
+impl<'a> PublicDependencyContainer<'a> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+    pub fn new_scope(&self) -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+}
+pub(crate) struct PublicCrateDependencyContainer<'a> {
+    _phantom: std::marker::PhantomData<&'a ()>,
+}
+#[automatically_derived]
+impl<'a> ::core::clone::Clone for PublicCrateDependencyContainer<'a> {
+    #[inline]
+    fn clone(&self) -> PublicCrateDependencyContainer<'a> {
+        PublicCrateDependencyContainer {
+            _phantom: ::core::clone::Clone::clone(&self._phantom),
+        }
+    }
+}
+impl<'a> PublicCrateDependencyContainer<'a> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+    pub fn new_scope(&self) -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+}
+pub(self) struct PublicSelfDependencyContainer<'a> {
+    _phantom: std::marker::PhantomData<&'a ()>,
+}
+#[automatically_derived]
+impl<'a> ::core::clone::Clone for PublicSelfDependencyContainer<'a> {
+    #[inline]
+    fn clone(&self) -> PublicSelfDependencyContainer<'a> {
+        PublicSelfDependencyContainer {
+            _phantom: ::core::clone::Clone::clone(&self._phantom),
+        }
+    }
+}
+impl<'a> PublicSelfDependencyContainer<'a> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+    pub fn new_scope(&self) -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+}
+mod outer {
+    pub(super) struct PublicSuperDependencyContainer<'a> {
+        _phantom: std::marker::PhantomData<&'a ()>,
+    }
+    #[automatically_derived]
+    impl<'a> ::core::clone::Clone for PublicSuperDependencyContainer<'a> {
+        #[inline]
+        fn clone(&self) -> PublicSuperDependencyContainer<'a> {
+            PublicSuperDependencyContainer {
+                _phantom: ::core::clone::Clone::clone(&self._phantom),
+            }
+        }
+    }
+    impl<'a> PublicSuperDependencyContainer<'a> {
+        pub fn new() -> Self {
+            Self {
+                _phantom: Default::default(),
+            }
+        }
+        pub fn new_scope(&self) -> Self {
+            Self {
+                _phantom: Default::default(),
+            }
+        }
+    }
+    mod inner {
+        pub(in crate::outer) struct PublicModInOuterDependencyContainer<'a> {
+            _phantom: std::marker::PhantomData<&'a ()>,
+        }
+        #[automatically_derived]
+        impl<'a> ::core::clone::Clone for PublicModInOuterDependencyContainer<'a> {
+            #[inline]
+            fn clone(&self) -> PublicModInOuterDependencyContainer<'a> {
+                PublicModInOuterDependencyContainer {
+                    _phantom: ::core::clone::Clone::clone(&self._phantom),
+                }
+            }
+        }
+        impl<'a> PublicModInOuterDependencyContainer<'a> {
+            pub fn new() -> Self {
+                Self {
+                    _phantom: Default::default(),
+                }
+            }
+            pub fn new_scope(&self) -> Self {
+                Self {
+                    _phantom: Default::default(),
+                }
+            }
+        }
+    }
+}
+fn main() {}

--- a/despatma-dependency-container/tests/expand/visibility.rs
+++ b/despatma-dependency-container/tests/expand/visibility.rs
@@ -1,0 +1,25 @@
+//! Test all the visibility levels of generated dependency containers.
+
+#[despatma_dependency_container::dependency_container]
+impl PrivateDependencyContainer {}
+
+#[despatma_dependency_container::dependency_container(pub)]
+impl PublicDependencyContainer {}
+
+#[despatma_dependency_container::dependency_container(pub(crate))]
+impl PublicCrateDependencyContainer {}
+
+#[despatma_dependency_container::dependency_container(pub(self))]
+impl PublicSelfDependencyContainer {}
+
+mod outer {
+    #[despatma_dependency_container::dependency_container(pub(super))]
+    impl PublicSuperDependencyContainer {}
+
+    mod inner {
+        #[despatma_dependency_container::dependency_container(pub(in crate::outer))]
+        impl PublicModInOuterDependencyContainer {}
+    }
+}
+
+fn main() {}

--- a/despatma/src/lib.rs
+++ b/despatma/src/lib.rs
@@ -715,6 +715,19 @@ pub use despatma_visitor::visitor_mut;
 ///
 /// **Important**: The linking between dependencies works because the `config()` method has the same name as the `config` argument in the `service` method. This name matching is crucial for the auto-wiring to function correctly.
 ///
+/// ## Container Visibility
+///
+/// By default, the generated container struct is private. To make it public, add a visibility modifier to the macro invocation:
+///
+/// ```
+/// use despatma::dependency_container;
+///
+/// #[dependency_container(pub)]
+/// impl MyContainer { }
+/// ```
+///
+/// The macro supports all Rust [visibility modifiers](https://doc.rust-lang.org/reference/visibility-and-privacy.html) including `pub`, `pub(crate)`, `pub(super)`, and `pub(in path)`.
+///
 /// ## Advanced Features
 ///
 /// ### Returning Traits


### PR DESCRIPTION
This is done by adding a visibility modifier on the macro invocation:

```rust
// `MyContainer` will be a `pub` struct
#[dependency_container(pub)]
impl MyContainer { }
```

Closes #40 