### PR TITLE
chore: release v0.3.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "despatma"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-once-cell",
  "auto_impl",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "despatma-abstract-factory"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "despatma-lib",
  "despatma-test-helpers",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "despatma-dependency-container"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-once-cell",
  "auto_impl",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "despatma-lib"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "despatma-test-helpers",
  "pretty_assertions",
@@ -96,14 +96,14 @@ dependencies = [
 
 [[package]]
 name = "despatma-test-helpers"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "pretty_assertions",
 ]
 
 [[package]]
 name = "despatma-visitor"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "convert_case",
  "despatma-lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.7"
+version = "0.3.8"
 
 [workspace]
 members = [

--- a/despatma-abstract-factory/Cargo.toml
+++ b/despatma-abstract-factory/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["macro", "design", "patterns", "abstract", "factory"]
 proc-macro = true
 
 [dependencies]
-despatma-lib = { version = "0.3.7", path = "../despatma-lib" }
+despatma-lib = { version = "0.3.8", path = "../despatma-lib" }
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["full"] }

--- a/despatma-dependency-container/CHANGELOG.md
+++ b/despatma-dependency-container/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.3.7...despatma-dependency-container-v0.3.8) - 2025-12-07
+
+### Added
+
+- *(di)* Added the ability to add dependencies when creating a container ([#43](https://github.com/chesedo/despatma/pull/43))
+
 ## [0.3.7](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.3.6...despatma-dependency-container-v0.3.7) - 2025-11-17
 
 ### Other

--- a/despatma-dependency-container/Cargo.toml
+++ b/despatma-dependency-container/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["design", "patterns", "dependency", "container", "injection"]
 proc-macro = true
 
 [dependencies]
-despatma-visitor = { version = "0.3.7", path = "../despatma-visitor" }
+despatma-visitor = { version = "0.3.8", path = "../despatma-visitor" }
 proc-macro-error2 = "2.0.0"
 proc-macro2.workspace = true
 quote.workspace = true

--- a/despatma-visitor/Cargo.toml
+++ b/despatma-visitor/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.9.0"
-despatma-lib = { version = "0.3.7", path = "../despatma-lib" }
+despatma-lib = { version = "0.3.8", path = "../despatma-lib" }
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true

--- a/despatma/CHANGELOG.md
+++ b/despatma/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/chesedo/despatma/compare/despatma-v0.3.7...despatma-v0.3.8) - 2025-12-07
+
+### Added
+
+- *(di)* Added the ability to add dependencies when creating a container ([#43](https://github.com/chesedo/despatma/pull/43))
+
 ## [0.3.7](https://github.com/chesedo/despatma/compare/despatma-v0.3.6...despatma-v0.3.7) - 2025-11-17
 
 ### Other

--- a/despatma/Cargo.toml
+++ b/despatma/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["macro", "design", "patterns"]
 
 [dependencies]
 async-once-cell.workspace = true
-despatma-abstract-factory = { version = "0.3.7", path = "../despatma-abstract-factory" }
-despatma-dependency-container = { version = "0.3.7", path = "../despatma-dependency-container", default-features = false }
-despatma-lib = { version = "0.3.7", path = "../despatma-lib" }
-despatma-visitor = { version = "0.3.7", path = "../despatma-visitor" }
+despatma-abstract-factory = { version = "0.3.8", path = "../despatma-abstract-factory" }
+despatma-dependency-container = { version = "0.3.8", path = "../despatma-dependency-container", default-features = false }
+despatma-lib = { version = "0.3.8", path = "../despatma-lib" }
+despatma-visitor = { version = "0.3.8", path = "../despatma-visitor" }
 
 [dev-dependencies]
 auto_impl = "1.2.0"


### PR DESCRIPTION



## 🤖 New release

* `despatma-lib`: 0.3.7 -> 0.3.8
* `despatma-abstract-factory`: 0.3.7 -> 0.3.8
* `despatma-visitor`: 0.3.7 -> 0.3.8
* `despatma-dependency-container`: 0.3.7 -> 0.3.8
* `despatma`: 0.3.7 -> 0.3.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `despatma-lib`

<blockquote>

## [0.3.0](https://github.com/chesedo/despatma/compare/despatma-lib-v0.2.0...despatma-lib-v0.3.0) - 2024-08-15

### Added
- [**breaking**] visitor_mut ([#13](https://github.com/chesedo/despatma/pull/13))
</blockquote>

## `despatma-abstract-factory`

<blockquote>

## [0.3.3](https://github.com/chesedo/despatma/compare/despatma-abstract-factory-v0.3.2...despatma-abstract-factory-v0.3.3) - 2024-09-18

### Other

- normalize all line endings ([#21](https://github.com/chesedo/despatma/pull/21))
</blockquote>

## `despatma-visitor`

<blockquote>

## [0.3.7](https://github.com/chesedo/despatma/compare/despatma-visitor-v0.3.6...despatma-visitor-v0.3.7) - 2025-11-17

### Other

- Update dev environment to cargo v1.89.0 and update dependencies ([#41](https://github.com/chesedo/despatma/pull/41))
</blockquote>

## `despatma-dependency-container`

<blockquote>

## [0.3.8](https://github.com/chesedo/despatma/compare/despatma-dependency-container-v0.3.7...despatma-dependency-container-v0.3.8) - 2025-12-07

### Added

- *(di)* Added the ability to add dependencies when creating a container ([#43](https://github.com/chesedo/despatma/pull/43))
</blockquote>

## `despatma`

<blockquote>

## [0.3.8](https://github.com/chesedo/despatma/compare/despatma-v0.3.7...despatma-v0.3.8) - 2025-12-07

### Added

- *(di)* Added the ability to add dependencies when creating a container ([#43](https://github.com/chesedo/despatma/pull/43))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).